### PR TITLE
Implement sidebar layout

### DIFF
--- a/frontend/public/css/layout.css
+++ b/frontend/public/css/layout.css
@@ -12,10 +12,60 @@
     margin: auto;
 }
 
+/* Sidebar Layout */
+.sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 250px;
+    height: 100vh;
+    background: linear-gradient(180deg, #4c1d95, #6d28d9);
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    z-index: 1000;
+}
+
+.sidebar .branding {
+    padding: 1.5rem;
+    font-size: 1.25rem;
+    font-weight: 700;
+    text-align: center;
+}
+
+.sidebar nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.sidebar nav li a {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1.5rem;
+    color: inherit;
+    text-decoration: none;
+    transition: background 0.2s ease-in-out;
+}
+
+.sidebar nav li a:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.sidebar .user-profile {
+    padding: 1.5rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.main-content {
+    margin-left: 250px;
+    padding: 2rem;
+}
+
 /* Dashboard Layout */
 .dashboard {
-    max-width: 1200px;
-    margin: 0 auto;
     padding: 2rem;
     min-height: 100vh;
 }
@@ -185,8 +235,6 @@
 
 /* Enhanced Dashboard Layouts */
 .dashboard {
-    max-width: 1400px;
-    margin: 0 auto;
     padding: 2rem;
     min-height: 100vh;
     background: var(--background);
@@ -359,6 +407,13 @@
 
 /* Responsive Enhancements */
 @media (max-width: 768px) {
+    .sidebar {
+        left: -250px;
+    }
+
+    .main-content {
+        margin-left: 0;
+    }
     .info-grid {
         grid-template-columns: 1fr;
         gap: 1rem;


### PR DESCRIPTION
## Summary
- add sidebar layout styles with gradient background
- define main content area and responsive rules
- remove centered dashboard widths

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852618f1e08832f9778bce7607ab247

## Summary by Sourcery

Implement a sidebar layout and adjust the dashboard to full-width display with responsive behavior

New Features:
- Add fixed sidebar layout with gradient background and separate branding, navigation, and user profile sections

Enhancements:
- Define main content area with left margin and padding for sidebar integration
- Remove fixed max-width centering on dashboard layouts to allow full-width display
- Introduce responsive rules to hide the sidebar and adjust content margins on smaller screens