### PR TITLE
Redesigned stat cards layout

### DIFF
--- a/frontend/public/css/components.css
+++ b/frontend/public/css/components.css
@@ -1537,7 +1537,6 @@
     display: flex;
     align-items: center;
     gap: 1rem;
-    border-left: 4px solid var(--primary);
 }
 
 .stat-icon {
@@ -1556,8 +1555,8 @@
 }
 
 .stat-value {
-    font-size: 1.5rem;
-    font-weight: 600;
+    font-size: 2rem;
+    font-weight: 700;
     color: var(--text-primary);
     margin-bottom: 0.25rem;
 }
@@ -1565,6 +1564,29 @@
 .stat-label {
     font-size: 0.875rem;
     color: var(--text-secondary);
+}
+
+.stat-trend {
+    font-size: 0.8rem;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-top: 0.25rem;
+}
+
+.icon-purple {
+    color: var(--purple);
+    background: rgba(124, 58, 237, 0.1);
+}
+
+.icon-green {
+    color: var(--success);
+    background: rgba(16, 185, 129, 0.1);
+}
+
+.icon-orange {
+    color: var(--warning);
+    background: rgba(245, 158, 11, 0.1);
 }
 
 .email-actions-grid {

--- a/frontend/public/css/layout.css
+++ b/frontend/public/css/layout.css
@@ -48,7 +48,7 @@
 /* Stats Grid */
 .stats-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(4, 1fr);
     gap: 1.5rem;
     margin-bottom: 2rem;
 }
@@ -58,14 +58,16 @@
     border-radius: var(--border-radius);
     padding: 1.5rem;
     box-shadow: var(--shadow);
-    border-left: 4px solid var(--primary);
+    display: flex;
+    align-items: center;
+    gap: 1rem;
 }
 
 .stat-value {
-    font-size: 2rem;
+    font-size: 2.25rem;
     font-weight: 700;
-    color: var(--primary);
-    margin-bottom: 0.5rem;
+    color: var(--text-primary);
+    margin-bottom: 0.25rem;
 }
 
 .stat-label {
@@ -73,6 +75,29 @@
     font-size: 0.9rem;
     text-transform: uppercase;
     letter-spacing: 0.5px;
+}
+
+.stat-trend {
+    font-size: 0.8rem;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-top: 0.25rem;
+}
+
+.icon-purple {
+    color: var(--purple);
+    background: rgba(124, 58, 237, 0.1);
+}
+
+.icon-green {
+    color: var(--success);
+    background: rgba(16, 185, 129, 0.1);
+}
+
+.icon-orange {
+    color: var(--warning);
+    background: rgba(245, 158, 11, 0.1);
 }
 
 /* Data Table Layout */

--- a/frontend/public/css/responsive.css
+++ b/frontend/public/css/responsive.css
@@ -1,3 +1,9 @@
+@media (max-width: 1024px) {
+    .stats-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
 @media (max-width: 768px) {
     .page-container {
         padding: 1rem;

--- a/frontend/public/css/variables.css
+++ b/frontend/public/css/variables.css
@@ -14,4 +14,5 @@
     --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
     --border-radius: 8px;
     --transition: all 0.2s ease-in-out;
+    --purple: #7c3aed;
 }

--- a/frontend/public/js/app.js
+++ b/frontend/public/js/app.js
@@ -687,20 +687,32 @@ const App = {
 
                 <div class="stats-grid">
                     <div class="stat-card">
-                        <div class="stat-value">${totalAttendees}</div>
-                        <div class="stat-label">Total Attendees</div>
+                        <div class="stat-icon icon-purple"><i class="fas fa-users"></i></div>
+                        <div class="stat-content">
+                            <div class="stat-value">${totalAttendees}</div>
+                            <div class="stat-label">Total Attendees</div>
+                        </div>
                     </div>
                     <div class="stat-card">
-                        <div class="stat-value">${Utils.formatCurrency(totalRevenue)}</div>
-                        <div class="stat-label">Total Revenue</div>
+                        <div class="stat-icon icon-purple"><i class="fas fa-pound-sign"></i></div>
+                        <div class="stat-content">
+                            <div class="stat-value">${Utils.formatCurrency(totalRevenue)}</div>
+                            <div class="stat-label">Total Revenue</div>
+                        </div>
                     </div>
                     <div class="stat-card">
-                        <div class="stat-value">${pendingPayments}</div>
-                        <div class="stat-label">Pending Payments</div>
+                        <div class="stat-icon icon-orange"><i class="fas fa-hourglass-half"></i></div>
+                        <div class="stat-content">
+                            <div class="stat-value">${pendingPayments}</div>
+                            <div class="stat-label">Pending Payments</div>
+                        </div>
                     </div>
                     <div class="stat-card">
-                        <div class="stat-value">${roomsOccupied}</div>
-                        <div class="stat-label">Rooms Occupied</div>
+                        <div class="stat-icon icon-green"><i class="fas fa-bed"></i></div>
+                        <div class="stat-content">
+                            <div class="stat-value">${roomsOccupied}</div>
+                            <div class="stat-label">Rooms Occupied</div>
+                        </div>
                     </div>
                 </div>
 

--- a/frontend/public/js/components/admin-dashboard.js
+++ b/frontend/public/js/components/admin-dashboard.js
@@ -74,20 +74,34 @@ const AdminDashboard = {
 
                 <div class="stats-grid" id="admin-stats">
                     <div class="stat-card">
-                        <div class="stat-value" id="total-attendees">0</div>
-                        <div class="stat-label">Total Attendees</div>
+                        <div class="stat-icon icon-purple"><i class="fas fa-users"></i></div>
+                        <div class="stat-content">
+                            <div class="stat-value" id="total-attendees">0</div>
+                            <div class="stat-label">Total Attendees</div>
+                        </div>
                     </div>
                     <div class="stat-card">
-                        <div class="stat-value" id="total-revenue">£0</div>
-                        <div class="stat-label">Total Revenue</div>
+                        <div class="stat-icon icon-purple"><i class="fas fa-pound-sign"></i></div>
+                        <div class="stat-content">
+                            <div class="stat-value" id="total-revenue">£0</div>
+                            <div class="stat-label">Total Revenue</div>
+                        </div>
                     </div>
                     <div class="stat-card">
-                        <div class="stat-value" id="pending-payments">0</div>
-                        <div class="stat-label">Pending Payments</div>
+                        <div class="stat-icon icon-orange"><i class="fas fa-hourglass-half"></i></div>
+                        <div class="stat-content">
+                            <div class="stat-value" id="pending-payments">0</div>
+                            <div class="stat-label">Pending Payments</div>
+                            <div class="stat-trend" id="pending-payments-trend"></div>
+                        </div>
                     </div>
                     <div class="stat-card">
-                        <div class="stat-value" id="active-announcements">0</div>
-                        <div class="stat-label">Active Announcements</div>
+                        <div class="stat-icon icon-green"><i class="fas fa-bullhorn"></i></div>
+                        <div class="stat-content">
+                            <div class="stat-value" id="active-announcements">0</div>
+                            <div class="stat-label">Active Announcements</div>
+                            <div class="stat-trend" id="active-announcements-trend"></div>
+                        </div>
                     </div>
                 </div>
 
@@ -367,11 +381,19 @@ const AdminDashboard = {
         const totalRevenueEl = document.getElementById('total-revenue');
         const pendingPaymentsEl = document.getElementById('pending-payments');
         const activeAnnouncementsEl = document.getElementById('active-announcements');
-        
+        const pendingTrendEl = document.getElementById('pending-payments-trend');
+        const activeTrendEl = document.getElementById('active-announcements-trend');
+
         if (totalAttendeesEl) totalAttendeesEl.textContent = stats.totalAttendees;
         if (totalRevenueEl) totalRevenueEl.textContent = Utils.formatCurrency(stats.totalRevenue);
         if (pendingPaymentsEl) pendingPaymentsEl.textContent = stats.pendingPayments;
         if (activeAnnouncementsEl) activeAnnouncementsEl.textContent = stats.activeAnnouncements;
+
+        const pendingPct = stats.totalAttendees > 0 ? Math.round((stats.pendingPayments / stats.totalAttendees) * 100) : 0;
+        const activePct = stats.totalAnnouncements > 0 ? Math.round((stats.activeAnnouncements / stats.totalAnnouncements) * 100) : 0;
+
+        if (pendingTrendEl) pendingTrendEl.innerHTML = `<i class="fas fa-arrow-up"></i> ${pendingPct}%`;
+        if (activeTrendEl) activeTrendEl.innerHTML = `<i class="fas fa-arrow-up"></i> ${activePct}%`;
     },
 
     /**

--- a/frontend/public/templates/admin-dashboard.html
+++ b/frontend/public/templates/admin-dashboard.html
@@ -25,20 +25,34 @@
 
     <div class="stats-grid" id="admin-stats">
         <div class="stat-card">
-            <div class="stat-value" id="total-attendees">0</div>
-            <div class="stat-label">Total Attendees</div>
+            <div class="stat-icon icon-purple"><i class="fas fa-users"></i></div>
+            <div class="stat-content">
+                <div class="stat-value" id="total-attendees">0</div>
+                <div class="stat-label">Total Attendees</div>
+            </div>
         </div>
         <div class="stat-card">
-            <div class="stat-value" id="total-revenue">£0</div>
-            <div class="stat-label">Total Revenue</div>
+            <div class="stat-icon icon-purple"><i class="fas fa-pound-sign"></i></div>
+            <div class="stat-content">
+                <div class="stat-value" id="total-revenue">£0</div>
+                <div class="stat-label">Total Revenue</div>
+            </div>
         </div>
         <div class="stat-card">
-            <div class="stat-value" id="pending-payments">0</div>
-            <div class="stat-label">Pending Payments</div>
+            <div class="stat-icon icon-orange"><i class="fas fa-hourglass-half"></i></div>
+            <div class="stat-content">
+                <div class="stat-value" id="pending-payments">0</div>
+                <div class="stat-label">Pending Payments</div>
+                <div class="stat-trend" id="pending-payments-trend"></div>
+            </div>
         </div>
         <div class="stat-card">
-            <div class="stat-value" id="active-announcements">0</div>
-            <div class="stat-label">Active Announcements</div>
+            <div class="stat-icon icon-green"><i class="fas fa-bullhorn"></i></div>
+            <div class="stat-content">
+                <div class="stat-value" id="active-announcements">0</div>
+                <div class="stat-label">Active Announcements</div>
+                <div class="stat-trend" id="active-announcements-trend"></div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- redesign stat cards with new layout and icons
- add purple color variable and icon color helpers
- update admin dashboard template and fallback markup
- show percentage indicators for pending payments and announcements
- adjust responsive grid for tablet/mobile

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685261cfcab0832fa2b74249b43598c2

## Summary by Sourcery

Redesign the admin dashboard stat cards with a new layout, colored icons, and trend indicators, introduce a purple theme variable, and adjust responsive grid behavior.

New Features:
- Show percentage trend indicators for pending payments and active announcements on stat cards

Enhancements:
- Redesign stats grid with a fixed four-column layout and flex-based stat cards including icon and content wrappers
- Add icon helper classes (icon-purple, icon-green, icon-orange) and introduce a --purple CSS variable
- Adjust responsive CSS breakpoints to switch the stats grid to two columns on medium screens