### PR TITLE
Add top header bar to dashboards

### DIFF
--- a/frontend/public/css/layout.css
+++ b/frontend/public/css/layout.css
@@ -20,12 +20,56 @@
     min-height: 100vh;
 }
 
-.dashboard-header {
+.top-header {
     background: var(--surface);
-    border-radius: var(--border-radius);
-    padding: 2rem;
+    padding: 0.75rem 2rem;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.top-header-left {
+    flex: 1;
+}
+
+.top-header-right {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.notification-icon {
+    font-size: 1.2rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+}
+
+.current-date {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.profile-dropdown {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.top-search {
+    max-width: 300px;
+    width: 100%;
+}
+
+.dashboard-header {
+    background: transparent;
+    border-radius: 0;
+    padding: 0;
     margin-bottom: 2rem;
-    box-shadow: var(--shadow);
+    box-shadow: none;
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/frontend/public/css/responsive.css
+++ b/frontend/public/css/responsive.css
@@ -7,6 +7,12 @@
         padding: 1rem;
     }
     
+    .top-header {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.5rem;
+    }
+
     .dashboard-header {
         flex-direction: column;
         align-items: stretch;
@@ -23,6 +29,10 @@
     }
     
     .search-box {
+        width: 100%;
+    }
+
+    .top-search {
         width: 100%;
     }
     
@@ -74,8 +84,12 @@
         padding: 1.5rem;
     }
     
+    .top-header {
+        padding: 1rem;
+    }
+
     .dashboard-header {
-        padding: 1.5rem;
+        padding: 1.5rem 0;
     }
     
     .table-header {
@@ -88,6 +102,10 @@
     }
     
     .search-box {
+        font-size: 0.9rem;
+    }
+
+    .top-search {
         font-size: 0.9rem;
     }
 }

--- a/frontend/public/js/components/admin-dashboard.js
+++ b/frontend/public/js/components/admin-dashboard.js
@@ -18,6 +18,9 @@ const AdminDashboard = {
             await this.loadAllData();
             this.bindEvents();
             this.setupTabNavigation();
+
+            // Update top header information
+            this.updateHeaderInfo();
             
             // Initialize email management with better error handling
             if (window.EmailManagement) {
@@ -57,6 +60,16 @@ const AdminDashboard = {
     renderFallback() {
         document.getElementById('app').innerHTML = `
             <div class="dashboard">
+                <div class="top-header">
+                    <div class="top-header-left">
+                        <input type="search" class="search-box top-search" placeholder="Search...">
+                    </div>
+                    <div class="top-header-right">
+                        <div id="current-date" class="current-date"></div>
+                        <i class="fas fa-bell notification-icon"></i>
+                        <div class="profile-dropdown"><span id="user-name">Admin</span> <i class="fas fa-caret-down"></i></div>
+                    </div>
+                </div>
                 <div class="dashboard-header">
                     <div>
                         <h1 class="dashboard-title">Admin Dashboard</h1>
@@ -355,6 +368,7 @@ const AdminDashboard = {
         this.updateAnnouncementsDisplay();
         this.updateRoomsDisplay();
         this.updateGroupsDisplay();
+        this.updateHeaderInfo();
     },
 
     /**
@@ -1177,6 +1191,29 @@ const AdminDashboard = {
             default:
                 return { text: 'Unknown', class: 'badge-secondary' };
         }
+    },
+
+    /**
+     * Update header information such as date and user name
+     */
+    updateHeaderInfo() {
+        this.updateDate();
+        this.updateUserName();
+    },
+
+    updateDate() {
+        const el = document.getElementById('current-date');
+        if (el) {
+            const now = new Date();
+            el.textContent = now.toLocaleDateString(undefined, {
+                year: 'numeric', month: 'short', day: 'numeric'
+            });
+        }
+    },
+
+    updateUserName() {
+        const el = document.getElementById('user-name');
+        if (el) el.textContent = 'Admin';
     },
 
     /**

--- a/frontend/public/js/components/attendee-dashboard.js
+++ b/frontend/public/js/components/attendee-dashboard.js
@@ -10,6 +10,7 @@ const AttendeeDashboard = {
             await this.render();
             await this.loadData();
             this.bindEvents();
+            this.updateHeaderInfo();
         } catch (error) {
             console.error('Failed to initialize attendee dashboard:', error);
             Utils.showAlert('Failed to load dashboard', 'error');
@@ -35,6 +36,16 @@ const AttendeeDashboard = {
     renderFallback() {
         document.getElementById('app').innerHTML = `
             <div class="dashboard">
+                <div class="top-header">
+                    <div class="top-header-left">
+                        <input type="search" class="search-box top-search" placeholder="Search...">
+                    </div>
+                    <div class="top-header-right">
+                        <div id="current-date" class="current-date"></div>
+                        <i class="fas fa-bell notification-icon"></i>
+                        <div class="profile-dropdown"><span id="user-name">User</span> <i class="fas fa-caret-down"></i></div>
+                    </div>
+                </div>
                 <div class="dashboard-header">
                     <div>
                         <h1 class="dashboard-title">Welcome, <span id="attendee-name-display">Loading...</span></h1>
@@ -143,9 +154,12 @@ const AttendeeDashboard = {
         
         // Update group information
         this.updateGroupInfo();
-        
+
         // Update detailed information
         this.updateDetailedInfo();
+
+        // Update header info
+        this.updateHeaderInfo();
     },
 
     /**
@@ -803,6 +817,30 @@ const AttendeeDashboard = {
                 </div>
             </div>
         `;
+    }
+    ,
+
+    /**
+     * Update header information such as date and user name
+     */
+    updateHeaderInfo() {
+        this.updateDate();
+        this.updateUserName();
+    },
+
+    updateDate() {
+        const el = document.getElementById('current-date');
+        if (el) {
+            const now = new Date();
+            el.textContent = now.toLocaleDateString(undefined, {
+                year: 'numeric', month: 'short', day: 'numeric'
+            });
+        }
+    },
+
+    updateUserName() {
+        const el = document.getElementById('user-name');
+        if (el && this.data) el.textContent = this.data.name;
     }
 };
 

--- a/frontend/public/templates/admin-dashboard.html
+++ b/frontend/public/templates/admin-dashboard.html
@@ -1,4 +1,14 @@
 <div class="dashboard">
+    <div class="top-header">
+        <div class="top-header-left">
+            <input type="search" class="search-box top-search" placeholder="Search...">
+        </div>
+        <div class="top-header-right">
+            <div id="current-date" class="current-date"></div>
+            <i class="fas fa-bell notification-icon"></i>
+            <div class="profile-dropdown"><span id="user-name">Admin</span> <i class="fas fa-caret-down"></i></div>
+        </div>
+    </div>
     <div class="dashboard-header">
         <div>
             <h1 class="dashboard-title">Admin Dashboard</h1>

--- a/frontend/public/templates/attendee-dashboard.html
+++ b/frontend/public/templates/attendee-dashboard.html
@@ -1,4 +1,14 @@
 <div class="dashboard">
+    <div class="top-header">
+        <div class="top-header-left">
+            <input type="search" class="search-box top-search" placeholder="Search...">
+        </div>
+        <div class="top-header-right">
+            <div id="current-date" class="current-date"></div>
+            <i class="fas fa-bell notification-icon"></i>
+            <div class="profile-dropdown"><span id="user-name">User</span> <i class="fas fa-caret-down"></i></div>
+        </div>
+    </div>
     <div class="dashboard-header">
         <div>
             <h1 class="dashboard-title">Welcome, <span id="attendee-name-display">Loading...</span></h1>


### PR DESCRIPTION
## Summary
- redesign dashboard header to a minimal bar
- include search, notifications, profile menu and date
- adjust admin and attendee templates and fallbacks
- update JS to populate header information
- refine responsive styles

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685262038104832fb114b978fbf0b6da

## Summary by Sourcery

Add a top header bar to admin and attendee dashboards with search, date, notifications, and profile menu, and update corresponding JS, templates, and CSS for the new layout and responsiveness

New Features:
- Add a minimal top header bar containing search input, current date, notification icon, and profile menu to both admin and attendee dashboards

Enhancements:
- Refactor dashboard header into a top-header layout and update fallback render methods
- Implement updateHeaderInfo (with updateDate and updateUserName) and trigger it during initialization and data refresh
- Adjust CSS layout and responsive rules to style the new top header and simplify existing dashboard-header styles