### PR TITLE
Add mobile sidebar and responsive tables

### DIFF
--- a/frontend/public/css/responsive.css
+++ b/frontend/public/css/responsive.css
@@ -1,4 +1,45 @@
+.sidebar-toggle {
+    display: none;
+}
+
 @media (max-width: 768px) {
+    .sidebar-toggle {
+        display: block;
+        position: fixed;
+        top: 1rem;
+        left: 1rem;
+        z-index: 1001;
+        background: var(--primary);
+        color: #fff;
+        border: none;
+        padding: 0.5rem;
+        border-radius: var(--border-radius);
+    }
+
+    .tab-navigation {
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 200px;
+        padding: 1rem;
+        background: var(--surface);
+        box-shadow: var(--shadow-lg);
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
+        flex-direction: column;
+        gap: 0.25rem;
+        overflow-y: auto;
+    }
+
+    body.sidebar-open .tab-navigation {
+        transform: translateX(0);
+    }
+
+    body.sidebar-open {
+        overflow: hidden;
+    }
+
     .page-container {
         padding: 1rem;
     }
@@ -36,11 +77,6 @@
     }
     
     .action-buttons {
-        flex-direction: column;
-        gap: 0.25rem;
-    }
-    
-    .tab-navigation {
         flex-direction: column;
         gap: 0.25rem;
     }
@@ -89,5 +125,42 @@
     
     .search-box {
         font-size: 0.9rem;
+    }
+}
+
+@media (max-width: 600px) {
+    .table {
+        border: 0;
+    }
+
+    .table thead {
+        display: none;
+    }
+
+    .table tr {
+        display: block;
+        margin-bottom: 1rem;
+        background: var(--surface);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
+    }
+
+    .table td {
+        display: flex;
+        justify-content: space-between;
+        padding: 0.5rem 1rem;
+        border: none;
+        border-bottom: 1px solid var(--border);
+    }
+
+    .table td:last-child {
+        border-bottom: none;
+    }
+
+    .table td::before {
+        content: attr(data-label);
+        font-weight: 600;
+        color: var(--text-secondary);
+        margin-right: 1rem;
     }
 }

--- a/frontend/public/js/components/admin-dashboard.js
+++ b/frontend/public/js/components/admin-dashboard.js
@@ -57,6 +57,7 @@ const AdminDashboard = {
     renderFallback() {
         document.getElementById('app').innerHTML = `
             <div class="dashboard">
+                <button class="sidebar-toggle" id="nav-toggle"><i class="fas fa-bars"></i></button>
                 <div class="dashboard-header">
                     <div>
                         <h1 class="dashboard-title">Admin Dashboard</h1>
@@ -120,7 +121,7 @@ const AdminDashboard = {
                             </div>
                         </div>
                         <div class="table-container">
-                            <table class="table">
+                            <table class="table card-view">
                                 <thead>
                                     <tr>
                                         <th>Reference</th>
@@ -158,7 +159,7 @@ const AdminDashboard = {
                             </div>
                         </div>
                         <div class="table-container">
-                            <table class="table">
+                            <table class="table card-view">
                                 <thead>
                                     <tr>
                                         <th>Title</th>
@@ -195,7 +196,7 @@ const AdminDashboard = {
                             </div>
                         </div>
                         <div class="table-container">
-                            <table class="table">
+                            <table class="table card-view">
                                 <thead>
                                     <tr>
                                         <th>Room Number</th>
@@ -230,7 +231,7 @@ const AdminDashboard = {
                             </div>
                         </div>
                         <div class="table-container">
-                            <table class="table">
+                            <table class="table card-view">
                                 <thead>
                                     <tr>
                                         <th>Group Name</th>
@@ -412,17 +413,17 @@ const AdminDashboard = {
                 
             return `
                 <tr data-attendee-id="${attendee.id}">
-                    <td style="text-align: center;">
+                    <td data-label="Select" style="text-align: center;">
                         <input type="checkbox" name="attendee-select" value="${attendee.id}">
                     </td>
-                    <td><strong>${Utils.escapeHtml(attendee.ref_number)}</strong></td>
-                    <td>${Utils.escapeHtml(attendee.name)}</td>
-                    <td>${emailDisplay}</td>
-                    <td>${attendee.room ? Utils.escapeHtml(attendee.room.number) : '<span class="badge badge-secondary">Unassigned</span>'}</td>
-                    <td><strong>${Utils.formatCurrency(paymentDue)}</strong></td>
-                    <td>${attendee.group ? Utils.escapeHtml(attendee.group.name) : '<span class="badge badge-secondary">No Group</span>'}</td>
-                    <td>${statusBadge}</td>
-                    <td>
+                    <td data-label="Reference"><strong>${Utils.escapeHtml(attendee.ref_number)}</strong></td>
+                    <td data-label="Name">${Utils.escapeHtml(attendee.name)}</td>
+                    <td data-label="Email">${emailDisplay}</td>
+                    <td data-label="Room">${attendee.room ? Utils.escapeHtml(attendee.room.number) : '<span class="badge badge-secondary">Unassigned</span>'}</td>
+                    <td data-label="Payment Due"><strong>${Utils.formatCurrency(paymentDue)}</strong></td>
+                    <td data-label="Group">${attendee.group ? Utils.escapeHtml(attendee.group.name) : '<span class="badge badge-secondary">No Group</span>'}</td>
+                    <td data-label="Status">${statusBadge}</td>
+                    <td data-label="Actions">
                         <div class="action-buttons" style="display: flex; gap: 0.25rem; flex-wrap: wrap;">
                             <button class="btn btn-sm btn-primary edit-attendee" data-id="${attendee.id}" title="Edit Attendee">
                                 <i class="fas fa-edit"></i>
@@ -477,33 +478,33 @@ const AdminDashboard = {
             
             return `
                 <tr data-announcement-id="${announcement.id}" ${isExpired ? 'style="opacity: 0.6;"' : ''}>
-                    <td>
+                    <td data-label="Title">
                         <div style="max-width: 200px;">
                             <strong>${Utils.escapeHtml(announcement.title)}</strong>
                             ${isExpired ? '<br><small style="color: var(--error);">Expired</small>' : ''}
                         </div>
                     </td>
-                    <td>
+                    <td data-label="Type">
                         <span class="badge ${typeBadge.class}">
                             <i class="${typeBadge.icon}"></i> ${typeBadge.text}
                         </span>
                     </td>
-                    <td>
+                    <td data-label="Priority">
                         <span class="badge ${priorityBadge.class}">
                             ${priorityBadge.text}
                         </span>
                     </td>
-                    <td>
+                    <td data-label="Target">
                         <span class="badge ${targetBadge.class}">
                             ${targetBadge.text}
                         </span>
                     </td>
-                    <td>${statusBadge}</td>
-                    <td>
+                    <td data-label="Status">${statusBadge}</td>
+                    <td data-label="Created">
                         <small>${createdDate}</small><br>
                         <small style="color: var(--text-secondary);">by ${Utils.escapeHtml(announcement.author_name)}</small>
                     </td>
-                    <td>
+                    <td data-label="Actions">
                         <div class="action-buttons">
                             <button class="btn btn-sm btn-primary edit-announcement" data-id="${announcement.id}" title="Edit Announcement">
                                 <i class="fas fa-edit"></i>
@@ -552,11 +553,11 @@ const AdminDashboard = {
                 
             return `
                 <tr data-room-id="${room.id}">
-                    <td><strong>${Utils.escapeHtml(room.number)}</strong></td>
-                    <td>${room.description ? Utils.escapeHtml(room.description) : '<span class="text-secondary">—</span>'}</td>
-                    <td>${occupancyBadge}</td>
-                    <td style="max-width: 200px; overflow: hidden; text-overflow: ellipsis;">${occupantsList}</td>
-                    <td>
+                    <td data-label="Number"><strong>${Utils.escapeHtml(room.number)}</strong></td>
+                    <td data-label="Description">${room.description ? Utils.escapeHtml(room.description) : '<span class="text-secondary">—</span>'}</td>
+                    <td data-label="Occupancy">${occupancyBadge}</td>
+                    <td data-label="Occupants" style="max-width: 200px; overflow: hidden; text-overflow: ellipsis;">${occupantsList}</td>
+                    <td data-label="Actions">
                         <div class="action-buttons">
                             <button class="btn btn-sm btn-primary edit-room" data-id="${room.id}" title="Edit Room">
                                 <i class="fas fa-edit"></i>
@@ -601,10 +602,10 @@ const AdminDashboard = {
                 
             return `
                 <tr data-group-id="${group.id}">
-                    <td><strong>${Utils.escapeHtml(group.name)}</strong></td>
-                    <td><span class="badge badge-secondary">${memberCount} members</span></td>
-                    <td style="max-width: 200px; overflow: hidden; text-overflow: ellipsis;">${membersList}</td>
-                    <td>
+                    <td data-label="Group"><strong>${Utils.escapeHtml(group.name)}</strong></td>
+                    <td data-label="Members"><span class="badge badge-secondary">${memberCount} members</span></td>
+                    <td data-label="Member List" style="max-width: 200px; overflow: hidden; text-overflow: ellipsis;">${membersList}</td>
+                    <td data-label="Outstanding">
                         <div style="text-align: right;">
                             <div style="font-weight: 600; color: ${totalOutstanding > 0 ? 'var(--warning)' : 'var(--success)'};">
                                 ${Utils.formatCurrency(totalOutstanding)}
@@ -618,7 +619,7 @@ const AdminDashboard = {
                             `}
                         </div>
                     </td>
-                    <td>
+                    <td data-label="Actions">
                         <div class="action-buttons">
                             <button class="btn btn-sm btn-primary edit-group" data-id="${group.id}" title="Edit Group">
                                 <i class="fas fa-edit"></i>
@@ -664,6 +665,14 @@ const AdminDashboard = {
      * Bind all event listeners
      */
     bindEvents() {
+        // Sidebar toggle
+        const navToggle = document.getElementById('nav-toggle');
+        if (navToggle) {
+            navToggle.addEventListener('click', () => {
+                document.body.classList.toggle('sidebar-open');
+            });
+        }
+
         // Logout button
         const logoutBtn = document.getElementById('admin-logout');
         if (logoutBtn) {

--- a/frontend/public/js/components/attendee-dashboard.js
+++ b/frontend/public/js/components/attendee-dashboard.js
@@ -35,6 +35,7 @@ const AttendeeDashboard = {
     renderFallback() {
         document.getElementById('app').innerHTML = `
             <div class="dashboard">
+                <button class="sidebar-toggle" id="nav-toggle"><i class="fas fa-bars"></i></button>
                 <div class="dashboard-header">
                     <div>
                         <h1 class="dashboard-title">Welcome, <span id="attendee-name-display">Loading...</span></h1>
@@ -374,6 +375,14 @@ const AttendeeDashboard = {
      * Bind event listeners (updated with announcements)
      */
     bindEvents() {
+        // Sidebar toggle
+        const navToggle = document.getElementById('nav-toggle');
+        if (navToggle) {
+            navToggle.addEventListener('click', () => {
+                document.body.classList.toggle('sidebar-open');
+            });
+        }
+
         // Logout button
         const logoutBtn = document.getElementById('attendee-logout');
         if (logoutBtn) {

--- a/frontend/public/templates/admin-dashboard.html
+++ b/frontend/public/templates/admin-dashboard.html
@@ -1,4 +1,5 @@
 <div class="dashboard">
+    <button class="sidebar-toggle" id="nav-toggle"><i class="fas fa-bars"></i></button>
     <div class="dashboard-header">
         <div>
             <h1 class="dashboard-title">Admin Dashboard</h1>
@@ -80,7 +81,7 @@
                 </div>
             </div>
             <div class="table-container">
-                <table class="table">
+                <table class="table card-view">
                     <thead>
                         <tr>
                             <th style="width: 40px;"><input type="checkbox" id="select-all-attendees" title="Select All"></th>
@@ -119,7 +120,7 @@
                 </div>
             </div>
             <div class="table-container">
-                <table class="table">
+                <table class="table card-view">
                     <thead>
                         <tr>
                             <th>Title</th>
@@ -306,7 +307,7 @@
                 </div>
             </div>
             <div class="table-container">
-                <table class="table">
+                <table class="table card-view">
                     <thead>
                         <tr>
                             <th>Number</th>
@@ -342,7 +343,7 @@
                 </div>
             </div>
             <div class="table-container">
-                <table class="table">
+                <table class="table card-view">
                     <thead>
                         <tr>
                             <th>Name</th>

--- a/frontend/public/templates/attendee-dashboard.html
+++ b/frontend/public/templates/attendee-dashboard.html
@@ -1,4 +1,5 @@
 <div class="dashboard">
+    <button class="sidebar-toggle" id="nav-toggle"><i class="fas fa-bars"></i></button>
     <div class="dashboard-header">
         <div>
             <h1 class="dashboard-title">Welcome, <span id="attendee-name-display">Loading...</span></h1>


### PR DESCRIPTION
## Summary
- add hamburger sidebar toggle and card view responsive CSS
- update admin and attendee dashboard templates with sidebar button and card tables
- set data-labels for responsive card layout in JS components
- toggle sidebar visibility in dashboard scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852627b4b70832fa62136e07e0f0722