### PR TITLE
Fix admin dashboard sidebar nav

### DIFF
--- a/frontend/public/js/components/admin-dashboard.js
+++ b/frontend/public/js/components/admin-dashboard.js
@@ -17,7 +17,7 @@ const AdminDashboard = {
             await this.render();
             await this.loadAllData();
             this.bindEvents();
-            this.setupTabNavigation();
+            this.setupSidebarNavigation();
 
             // Update top header information
             this.updateHeaderInfo();


### PR DESCRIPTION
## Summary
- call `setupSidebarNavigation()` during dashboard init so sidebar menu works

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685292d89b9c832fb9f80cd08904f992

## Summary by Sourcery

Bug Fixes:
- Invoke setupSidebarNavigation during dashboard init instead of setupTabNavigation to restore sidebar menu navigation