### PR TITLE
Fix bulk email footer sender

### DIFF
--- a/functions/api/admin/email/send.js
+++ b/functions/api/admin/email/send.js
@@ -50,7 +50,7 @@ export async function onRequestPost(context) {
       subject,
       message,
       email_type,
-      sender: admin.user || 'Admin'
+      sender: 'The Growth and Wisdom Retreat Team'
     });
 
     return createResponse({


### PR DESCRIPTION
## Summary
- ensure bulk emails always show a standard sender

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68659b33e080832f8f59a4a7b0ce09c8

## Summary by Sourcery

Bug Fixes:
- Always set the sender for bulk emails to 'The Growth and Wisdom Retreat Team' instead of using the admin user fallback.