### PR TITLE
Add IP address to login history

### DIFF
--- a/frontend/public/js/components/admin-dashboard.js
+++ b/frontend/public/js/components/admin-dashboard.js
@@ -667,7 +667,7 @@ const AdminDashboard = {
         if (this.data.loginHistory.length === 0) {
             tbody.innerHTML = `
                 <tr>
-                    <td colspan="3" style="text-align: center; color: var(--text-secondary); padding: 2rem;">
+                    <td colspan="4" style="text-align: center; color: var(--text-secondary); padding: 2rem;">
                         No login history found
                     </td>
                 </tr>`;
@@ -680,6 +680,7 @@ const AdminDashboard = {
                 <tr>
                     <td>${Utils.escapeHtml(record.user_id)}</td>
                     <td>${Utils.escapeHtml(record.user_type)}</td>
+                    <td>${Utils.escapeHtml(record.ip_address || '')}</td>
                     <td>${time}</td>
                 </tr>`;
         }).join('');

--- a/frontend/public/templates/admin-dashboard.html
+++ b/frontend/public/templates/admin-dashboard.html
@@ -384,12 +384,13 @@
                         <tr>
                             <th>User</th>
                             <th>Type</th>
+                            <th>IP Address</th>
                             <th>Login Time</th>
                         </tr>
                     </thead>
                     <tbody id="login-history-body">
                         <tr>
-                            <td colspan="3" class="loading-placeholder">
+                            <td colspan="4" class="loading-placeholder">
                                 <i class="fas fa-spinner fa-spin"></i> Loading history...
                             </td>
                         </tr>

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,5 +1,6 @@
 // functions/_middleware.js
 // Enhanced middleware for session management, rate limiting, and security - FIXED VERSION
+import { getClientIP } from './_shared/auth.js';
 
 /**
  * Rate Limiter Class for request throttling (local version to avoid conflicts)
@@ -313,10 +314,7 @@ export async function onRequest(context) {
         }
 
         // Get client information
-        const clientIP = request.headers.get('CF-Connecting-IP') || 
-                        request.headers.get('X-Forwarded-For') || 
-                        request.headers.get('X-Real-IP') || 
-                        'unknown';
+        const clientIP = getClientIP(request);
         
         const userAgent = request.headers.get('User-Agent') || '';
         const sessionId = request.headers.get('X-Session-ID') || '';

--- a/functions/_shared/auth.js
+++ b/functions/_shared/auth.js
@@ -108,3 +108,26 @@ export function handleCORS() {
     }
   });
 }
+
+/**
+ * Extract the client IP address from request headers
+ * Returns 'unknown' if no valid IP can be determined
+ */
+export function getClientIP(request) {
+  const cf = request.headers.get('CF-Connecting-IP');
+  const xff = request.headers.get('X-Forwarded-For');
+  const real = request.headers.get('X-Real-IP');
+  const raw = cf || xff || real || '';
+  const first = raw.split(',')[0].trim();
+  return isValidIP(first) ? first : 'unknown';
+}
+
+/**
+ * Basic IPv4/IPv6 validation
+ */
+function isValidIP(ip) {
+  if (!ip) return false;
+  const ipv4 = /^((25[0-5]|2[0-4]\d|1?\d?\d)(\.|$)){4}$/;
+  const ipv6 = /^[0-9a-fA-F:]{2,45}$/;
+  return ipv4.test(ip) || ipv6.test(ip);
+}

--- a/functions/api/admin/login.js
+++ b/functions/api/admin/login.js
@@ -30,11 +30,17 @@ export async function onRequestPost(context) {
     
     console.log('Admin login successful for:', user);
 
+    const ipAddress =
+      context.request.headers.get('CF-Connecting-IP') ||
+      context.request.headers.get('X-Forwarded-For') ||
+      context.request.headers.get('X-Real-IP') ||
+      'unknown';
+
     // Record login history
     await context.env.DB.prepare(`
-      INSERT INTO login_history (user_type, user_id, login_time)
-      VALUES ('admin', ?, CURRENT_TIMESTAMP)
-    `).bind(user.trim()).run();
+      INSERT INTO login_history (user_type, user_id, ip_address, login_time)
+      VALUES ('admin', ?, ?, CURRENT_TIMESTAMP)
+    `).bind(user.trim(), ipAddress).run();
 
     // Create admin token
     const token = 'admin-token-' + btoa(user + ':' + Date.now() + ':admin');

--- a/functions/api/admin/login.js
+++ b/functions/api/admin/login.js
@@ -1,5 +1,5 @@
 // functions/api/admin/login.js - Updated admin login
-import { createResponse, handleCORS } from '../../_shared/auth.js';
+import { createResponse, handleCORS, getClientIP } from '../../_shared/auth.js';
 
 // Handle CORS preflight
 export async function onRequestOptions() {
@@ -30,11 +30,7 @@ export async function onRequestPost(context) {
     
     console.log('Admin login successful for:', user);
 
-    const ipAddress =
-      context.request.headers.get('CF-Connecting-IP') ||
-      context.request.headers.get('X-Forwarded-For') ||
-      context.request.headers.get('X-Real-IP') ||
-      'unknown';
+    const ipAddress = getClientIP(context.request);
 
     // Record login history
     await context.env.DB.prepare(`

--- a/functions/api/admin/reports/login-history.js
+++ b/functions/api/admin/reports/login-history.js
@@ -15,7 +15,7 @@ export async function onRequestGet(context) {
     }
 
     const { results } = await context.env.DB.prepare(`
-      SELECT id, user_type, user_id, login_time
+      SELECT id, user_type, user_id, ip_address, login_time
       FROM login_history
       ORDER BY datetime(login_time) DESC
       LIMIT 20

--- a/functions/api/login.js
+++ b/functions/api/login.js
@@ -1,5 +1,5 @@
 // functions/api/login.js - Updated attendee login
-import { createResponse, checkAttendeeAuth, handleCORS, hashPassword, verifyPassword } from '../_shared/auth.js';
+import { createResponse, checkAttendeeAuth, handleCORS, hashPassword, verifyPassword, getClientIP } from '../_shared/auth.js';
 
 // Handle CORS preflight
 export async function onRequestOptions() {
@@ -41,11 +41,7 @@ export async function onRequestPost(context) {
     
     console.log('Login successful for:', ref);
 
-    const ipAddress =
-      context.request.headers.get('CF-Connecting-IP') ||
-      context.request.headers.get('X-Forwarded-For') ||
-      context.request.headers.get('X-Real-IP') ||
-      'unknown';
+    const ipAddress = getClientIP(context.request);
 
     // Record login history and update last_login
     await context.env.DB.prepare(`

--- a/functions/api/login.js
+++ b/functions/api/login.js
@@ -41,11 +41,17 @@ export async function onRequestPost(context) {
     
     console.log('Login successful for:', ref);
 
+    const ipAddress =
+      context.request.headers.get('CF-Connecting-IP') ||
+      context.request.headers.get('X-Forwarded-For') ||
+      context.request.headers.get('X-Real-IP') ||
+      'unknown';
+
     // Record login history and update last_login
     await context.env.DB.prepare(`
-      INSERT INTO login_history (user_type, user_id, login_time)
-      VALUES ('attendee', ?, CURRENT_TIMESTAMP)
-    `).bind(ref.trim()).run();
+      INSERT INTO login_history (user_type, user_id, ip_address, login_time)
+      VALUES ('attendee', ?, ?, CURRENT_TIMESTAMP)
+    `).bind(ref.trim(), ipAddress).run();
 
     await context.env.DB.prepare(`
       UPDATE attendees SET last_login = CURRENT_TIMESTAMP

--- a/migrations/004_login_history_ip.sql
+++ b/migrations/004_login_history_ip.sql
@@ -1,4 +1,4 @@
 -- migrations/004_login_history_ip.sql
 -- Add ip_address column to login_history table
 
-ALTER TABLE login_history ADD COLUMN ip_address TEXT;
+ALTER TABLE login_history ADD COLUMN ip_address VARCHAR(45);

--- a/migrations/004_login_history_ip.sql
+++ b/migrations/004_login_history_ip.sql
@@ -1,0 +1,4 @@
+-- migrations/004_login_history_ip.sql
+-- Add ip_address column to login_history table
+
+ALTER TABLE login_history ADD COLUMN ip_address TEXT;


### PR DESCRIPTION
## Summary
- track IP address for attendee and admin logins
- expose IP address in login history API
- display IP address in the admin dashboard
- provide migration to add the ip column

## Testing
- `node --check functions/api/login.js`
- `node --check functions/api/admin/login.js`
- `node --check functions/api/admin/reports/login-history.js`
- `node --check frontend/public/js/components/admin-dashboard.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686bf6dfe7bc832f9e74dfade57b16f1

## Summary by Sourcery

Track and store client IP addresses on login, expose them via the login history API, update the admin dashboard to display IPs, and add a database migration for the new ip_address column.

New Features:
- Record client IP addresses for attendee and admin logins
- Expose the IP address in the login history API
- Display IP addresses in the admin dashboard login history table

Enhancements:
- Update API handlers and UI templates to include the ip_address field

Chores:
- Add a database migration to add the ip_address column to the login_history table