### PR TITLE
fix(admin-approve): compute next ref number numerically to unblock approvals

### DIFF
--- a/functions/api/admin/registrations/[id].ts
+++ b/functions/api/admin/registrations/[id].ts
@@ -373,27 +373,35 @@ export async function onRequestDelete(context: PagesContext<IdParams>): Promise<
   }
 }
 
-// Helper: read the current highest REF<YY>#### suffix for this year. Callers
+// Helper: read the current highest REF<YY>#### number for this year. Callers
 // add their own per-row and per-retry offsets to allocate fresh numbers; the
 // INSERT batch is what actually claims them, so concurrent approvals reconcile
 // by retrying the batch from a freshly-read (and therefore higher) base.
+//
+// This MUST compute the true NUMERIC maximum, not a text one. Ref numbers are
+// `REF<YY><n>`; an earlier version did `ORDER BY ref_number DESC LIMIT 1` and
+// parsed the tail, but that sorts lexicographically. A single non-uniformly
+// padded or non-numeric legacy ref (e.g. "REF269" or "REF26ABC", from a bulk
+// import or hand-entry) then sorts ABOVE the real highest number, collapsing
+// the computed base to a tiny value (or 0 on a NaN parse). Every base+1..base+N
+// the caller tried already existed, so the INSERT batch failed the UNIQUE
+// ref_number constraint on all retries and approval was wedged for the whole
+// table. MAX(CAST(SUBSTR(...))) takes the highest actual number and is immune
+// to text ordering and stray formats — non-numeric tails CAST to 0 and simply
+// lose the MAX, so they can never drag the base down.
 async function nextRefNumberBase(db: D1Database): Promise<number> {
   const prefix = 'REF';
   const year = new Date().getFullYear().toString().slice(-2);
 
-  const { results } = await db.prepare(`
-    SELECT ref_number FROM attendees
+  // SUBSTR(ref_number, 6) is the digits after the 5-char "REF<YY>" prefix
+  // (SQLite SUBSTR is 1-indexed), matching the format this helper emits.
+  const row = await db.prepare(`
+    SELECT MAX(CAST(SUBSTR(ref_number, 6) AS INTEGER)) AS num_max
+    FROM attendees
     WHERE ref_number LIKE ?
-    ORDER BY ref_number DESC
-    LIMIT 1
-  `).bind(`${prefix}${year}%`).all();
+  `).bind(`${prefix}${year}%`).first<{ num_max: number | null }>();
 
-  if (results.length > 0) {
-    const lastRef = (results[0] as unknown as { ref_number: string }).ref_number;
-    const numPart = parseInt(lastRef.slice(5), 10);
-    if (!isNaN(numPart)) return numPart;
-  }
-  return 0;
+  return row?.num_max ?? 0;
 }
 
 // Helper: approve a registration that has NO attendee accounts yet. Inserts a


### PR DESCRIPTION
## Problem

Approving **any** registration in production failed, every retry, with:

```
D1_ERROR: UNIQUE constraint failed: attendees.ref_number: SQLITE_CONSTRAINT
```

Production logs (reg #40) showed the existing-attendee guard correctly returning `0` (no orphans — the atomic-approval fix from #24 is working), then the INSERT batch colliding on `ref_number` across all 5 retries. A `base+1` collision is impossible if `base` is the true maximum, so `nextRefNumberBase` was under-counting.

## Root cause

`nextRefNumberBase` picked the "highest" ref with `ORDER BY ref_number DESC LIMIT 1` and parsed its tail — a **lexicographic** sort. Ref numbers are `REF<YY><n>`. A single non-uniformly-padded or non-numeric `REF26…` row already in the table (e.g. `REF269` or `REF26ABC`, which the manual *Add Attendee* / bulk-upload path allows, since it accepts `ref_number` from the request body unvalidated) sorts **above** the real highest number. The parsed base then collapsed to a tiny value — or to `0` when the tail wasn't numeric and `parseInt` returned `NaN`. `base+1 … base+N` were therefore low, long-since-used numbers, so every INSERT attempt hit the UNIQUE constraint and approval was **wedged for the entire table**, not just one registration.

## Fix

Compute the true **numeric** maximum directly in SQL:

```sql
SELECT MAX(CAST(SUBSTR(ref_number, 6) AS INTEGER)) AS num_max
FROM attendees
WHERE ref_number LIKE 'REF<YY>%'
```

This is immune to text ordering and stray formats — non-numeric tails `CAST` to `0` and lose the `MAX`, so they can't drag the base down. `base+1` is now guaranteed free; the existing per-retry re-read still handles genuine concurrency races.

## Verification

- `tsc --noEmit` passes (strict).
- Reproduced in SQLite: with rows `REF260001..REF260072` plus a stray `REF26ABC`, the old path resolved `base` to `0` (→ collide on `REF260001`); the new path resolves `72` → next free `REF260073`.

## Scope

One-line behavioural change to ref-number allocation in `functions/api/admin/registrations/[id].ts`. Verified this is the only backend path that generates ref numbers. The *Add Attendee* endpoint's lack of ref-format validation (the likely source of the bad row) is left untouched — it's a separate, optional hardening, and this fix makes approval robust regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TM9EsRHSBTB4vMRKrRDrRB)_