### PR TITLE
ci(d1): automate D1 migrations so schema ships with code

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -1,0 +1,74 @@
+name: D1 migrations
+
+# Applies pending D1 migrations to the production database so the schema ships
+# with the code instead of being applied by hand (the gap that let
+# `no such column: a.preferred_name` reach production after 023 was merged).
+#
+# Mechanism: `wrangler d1 migrations apply` records every applied file in a
+# `d1_migrations` table and runs ONLY the ones not yet recorded. The existing
+# 001–023 were applied by hand, so the database must be baselined ONCE (see
+# migrations/README.md) before this can run — the "Verify baseline" step below
+# refuses to proceed otherwise, which is what stops wrangler from ever deciding
+# the destructive 002 (DROP TABLE attendees) is "pending" and re-running it.
+#
+# Required repo secrets:
+#   CLOUDFLARE_API_TOKEN   - token with D1 edit on the account
+#   CLOUDFLARE_ACCOUNT_ID  - 9dbefd5c67069aa84dbc395946c55839
+
+on:
+  push:
+    branches: [main]
+    paths: ["migrations/**"]
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "apply" to actually run pending migrations. Anything else just lists them.'
+        required: true
+        default: "list"
+
+concurrency:
+  group: d1-migrations
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      DB_NAME: attendance_db
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # Install wrangler globally rather than using the repo's committed
+      # node_modules — those carry a non-Linux workerd binary that crashes
+      # wrangler on startup. A global install is a clean, platform-correct copy.
+      - name: Install wrangler
+        run: npm install -g wrangler@^3
+
+      - name: Show pending migrations
+        run: wrangler d1 migrations list "$DB_NAME" --remote
+
+      # Safety gate: never apply unless the database is baselined. If the
+      # d1_migrations table is missing (or doesn't record 002), wrangler would
+      # treat every legacy migration as pending and re-run them — including
+      # 002's DROP TABLE attendees. Abort instead.
+      - name: Verify baseline
+        run: |
+          if wrangler d1 execute "$DB_NAME" --remote \
+               --command "SELECT name FROM d1_migrations WHERE name = '002_improved.schema.sql'" 2>/dev/null \
+               | grep -q "002_improved.schema.sql"; then
+            echo "Baseline present — safe to apply pending migrations."
+          else
+            echo "::error::Database is not baselined: d1_migrations is missing the foundational entries."
+            echo "Run scripts/baseline-d1-migrations.sql against the database ONCE first (see migrations/README.md)."
+            exit 1
+          fi
+
+      - name: Apply pending migrations
+        if: github.event_name == 'push' || github.event.inputs.confirm == 'apply'
+        run: wrangler d1 migrations apply "$DB_NAME" --remote

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,70 @@
+# Database migrations
+
+D1 schema changes live here as numbered SQL files (`001_*.sql` … `NNN_*.sql`).
+Historically they were applied by hand in the Cloudflare D1 console, which is
+how migration 023 shipped in code but never reached production — attendees hit
+`D1_ERROR: no such column: a.preferred_name` on login. This directory is now
+wired to **`wrangler d1 migrations`** so the schema ships with the code.
+
+## How it works
+
+`wrangler d1 migrations apply` records each applied file in a `d1_migrations`
+table and runs **only** the files not yet recorded. The
+[`d1-migrations` workflow](../.github/workflows/d1-migrations.yml) runs it
+against production whenever a `migrations/**` change lands on `main`, and can
+also be run manually from the Actions tab.
+
+## One-time setup (required before the workflow can apply anything)
+
+1. **Add repo secrets** (Settings → Secrets and variables → Actions):
+   - `CLOUDFLARE_API_TOKEN` — a token with **D1 edit** permission on the account.
+   - `CLOUDFLARE_ACCOUNT_ID` — `9dbefd5c67069aa84dbc395946c55839`.
+
+2. **Baseline the production database.** 001–023 are already applied by hand, so
+   wrangler must be told that — otherwise it would consider them pending and
+   re-run them, including `002`'s `DROP TABLE attendees`. First make sure every
+   listed migration (especially **023** — confirm its seven columns exist on
+   `attendees`) is genuinely applied, then run **once**:
+
+   ```bash
+   npx wrangler d1 execute attendance_db --remote --file=./scripts/baseline-d1-migrations.sql
+   ```
+
+3. **Validate, then trust it.** From the Actions tab → **D1 migrations** →
+   *Run workflow* with the default `list` to confirm wrangler reports
+   "No migrations to apply" (proof the baseline took). After that, merges that
+   touch `migrations/**` apply automatically. The workflow's **Verify baseline**
+   step hard-fails if step 2 was skipped, so a misconfigured run can't wipe data.
+
+## Adding a migration
+
+1. Create the next file continuing the **three-digit** sequence, e.g.
+   `024_add_widget_table.sql`. (Keep the existing numbering — don't use
+   `wrangler d1 migrations create`, which emits four-digit names that sort
+   inconsistently against these.)
+2. Keep it **additive and console-safe**: one statement per line, no semicolons
+   inside comments. SQLite has no `ADD COLUMN IF NOT EXISTS`, so a migration
+   must never be edited after it has been applied anywhere — always add a new
+   file.
+3. Open a PR. On merge to `main`, the workflow applies it to production.
+
+### Race note
+
+The migration workflow and the Cloudflare Pages deploy are triggered by the
+same merge but run independently, so for a few seconds new code may run against
+the old schema. Keep changes **additive** (add columns/tables; backfill;
+read both old and new) rather than renaming or dropping in the same release,
+and the brief overlap is harmless. For a destructive change, use the
+expand/contract pattern across two releases.
+
+## Manual commands
+
+```bash
+# What's pending against production
+npx wrangler d1 execute attendance_db --remote \
+  --command "SELECT name FROM d1_migrations ORDER BY id"
+npx wrangler d1 migrations list attendance_db --remote
+
+# Apply pending migrations to production
+npx wrangler d1 migrations apply attendance_db --remote
+```

--- a/scripts/baseline-d1-migrations.sql
+++ b/scripts/baseline-d1-migrations.sql
@@ -1,0 +1,49 @@
+/*
+  ONE-TIME baseline for adopting wrangler-managed D1 migrations on a database
+  whose 001..023 migrations were already applied by hand.
+
+  It creates the d1_migrations bookkeeping table (same shape wrangler creates)
+  and records every existing migration as already-applied, so the very first
+  `wrangler d1 migrations apply` runs ONLY genuinely-new files (024+) instead of
+  re-running everything — most importantly NOT re-running 002's DROP TABLE.
+
+  Run this ONCE against production, AFTER confirming all 23 files below are
+  truly applied (in particular 023 — verify its 7 columns exist on `attendees`).
+  Re-running is harmless: INSERT OR IGNORE skips names already present.
+
+    npx wrangler d1 execute attendance_db --remote --file=./scripts/baseline-d1-migrations.sql
+
+  This file lives outside migrations/ on purpose so wrangler never treats it as
+  a migration.
+*/
+
+CREATE TABLE IF NOT EXISTS d1_migrations (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  name       TEXT UNIQUE,
+  applied_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT OR IGNORE INTO d1_migrations (name) VALUES
+  ('001_schema.sql'),
+  ('002_improved.schema.sql'),
+  ('003_login_history.sql'),
+  ('004_login_attempts.sql'),
+  ('005_performance_indexes.sql'),
+  ('006_registrations.sql'),
+  ('007_family_registration.sql'),
+  ('008_attendee_payment_option.sql'),
+  ('009_payments.sql'),
+  ('010_activity_teams.sql'),
+  ('011_enhancements.sql'),
+  ('012_attendee_personal_details.sql'),
+  ('013_backfill_attendee_dob.sql'),
+  ('014_force_legacy_password_reset.sql'),
+  ('015_register_attempts.sql'),
+  ('016_create_announcements_and_normalise_archive.sql'),
+  ('017_room_cot_capacity.sql'),
+  ('018_settings_table.sql'),
+  ('019_allergy_registry.sql'),
+  ('020_admins_table.sql'),
+  ('021_flexible_payment_plans.sql'),
+  ('022_group_lead.sql'),
+  ('023_attendee_personal_details_expansion.sql');

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,6 +8,9 @@ compatibility_flags = ["nodejs_compat"]
 binding = "DB"
 database_name = "attendance_db"
 database_id = "19c293e9-c7b2-4fb6-bbee-e7960698cd8d"
+# Lets `wrangler d1 migrations apply` record applied migrations in the
+# d1_migrations table and run only pending files. See migrations/README.md.
+migrations_dir = "migrations"
 
 # Pages configuration
 [build]


### PR DESCRIPTION
## Why

Migrations in `migrations/` were applied by hand via the D1 console, so the code and the live schema drift. That gap just bit production: migration `023` shipped in code but was never applied, and every newly-approved attendee hit `D1_ERROR: no such column: a.preferred_name` on login (`/api/me` selects the columns 023 adds). This wires the repo to **wrangler-managed D1 migrations** so schema changes ship with the code.

## What's in here

- **`wrangler.toml`** — `migrations_dir = "migrations"`, so `wrangler d1 migrations apply` records applied files in a `d1_migrations` table and runs **only pending** ones.
- **`.github/workflows/d1-migrations.yml`** — applies pending migrations to production when a `migrations/**` change lands on `main` (also runnable manually from the Actions tab; manual runs default to *list-only* unless you pass `confirm: apply`).
- **`scripts/baseline-d1-migrations.sql`** — one-time bookkeeping that records the 23 already-applied migrations. Kept **outside** `migrations/` so wrangler never treats it as a migration.
- **`migrations/README.md`** — required secrets, the one-time baseline, how to add a migration, and additive-change/race guidance.

## Safety

The existing 001–023 were applied by hand, so wrangler doesn't know about them. Without a baseline it would treat them as pending and re-run them — including `002`'s `DROP TABLE attendees`. The workflow's **Verify baseline** step hard-fails unless `d1_migrations` records `002`, so a misconfigured run can't wipe data. No application code paths change.

## Operator setup required before it does anything (see `migrations/README.md`)

1. Add repo secrets `CLOUDFLARE_API_TOKEN` (D1 edit) and `CLOUDFLARE_ACCOUNT_ID` (`9dbefd5c67069aa84dbc395946c55839`).
2. After confirming 023 is applied, run the baseline script against prod **once**.
3. Trigger the workflow manually with the default `list` to confirm "No migrations to apply", then it's hands-off on future merges.

## Notes / limits

- Authored but not executed from here (this environment has no Cloudflare auth, and the committed `node_modules` carries a non-Linux `workerd`; the workflow installs wrangler globally to sidestep that). First manual dispatch validates it end-to-end.
- Keep new migrations additive and continue the three-digit numbering (`024_*.sql`); the README explains why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TM9EsRHSBTB4vMRKrRDrRB)_