### PR TITLE
fix(security): XSS/email-injection escaping, admin-reset throttling, session TTL

### DIFF
--- a/frontend/public/js/components/admin-dashboard.js
+++ b/frontend/public/js/components/admin-dashboard.js
@@ -2173,10 +2173,10 @@ const AdminDashboard = {
             ? familyMembers.map(m => `
                 <tr>
                     <td>${Utils.escapeHtml(m.name)}</td>
-                    <td>${m.date_of_birth || '-'}</td>
-                    <td><span class="badge badge-${m.member_type === 'adult' ? 'primary' : m.member_type === 'child' ? 'info' : 'secondary'}">${m.member_type}</span></td>
+                    <td>${Utils.escapeHtml(m.date_of_birth || '-')}</td>
+                    <td><span class="badge badge-${m.member_type === 'adult' ? 'primary' : m.member_type === 'child' ? 'info' : 'secondary'}">${Utils.escapeHtml(m.member_type)}</span></td>
                     <td>${Utils.formatCurrency(m.price || 0)}</td>
-                    <td>${m.dietary || '-'}</td>
+                    <td>${Utils.escapeHtml(m.dietary || '-')}</td>
                 </tr>
             `).join('')
             : `<tr><td colspan="5" style="text-align: center;">No family member details available</td></tr>`;
@@ -2196,8 +2196,8 @@ const AdminDashboard = {
                             <div class="detail-grid" style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
                                 <div><strong>Name:</strong> ${Utils.escapeHtml(registration.name)}</div>
                                 <div><strong>Email:</strong> ${Utils.escapeHtml(registration.email)}</div>
-                                <div><strong>Phone:</strong> ${registration.phone || '-'}</div>
-                                <div><strong>Emergency Contact:</strong> ${registration.emergency_contact || '-'}</div>
+                                <div><strong>Phone:</strong> ${Utils.escapeHtml(registration.phone || '-')}</div>
+                                <div><strong>Emergency Contact:</strong> ${Utils.escapeHtml(registration.emergency_contact || '-')}</div>
                             </div>
                         </div>
                         <div class="detail-section" style="margin-top: 1.5rem;">
@@ -2219,8 +2219,8 @@ const AdminDashboard = {
                             <h4>Payment & Status</h4>
                             <div class="detail-grid" style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
                                 <div><strong>Total Amount:</strong> ${Utils.formatCurrency(registration.total_amount || 200)}</div>
-                                <div><strong>Payment Option:</strong> ${registration.payment_option || 'full'}</div>
-                                <div><strong>Status:</strong> ${registration.status}</div>
+                                <div><strong>Payment Option:</strong> ${Utils.escapeHtml(registration.payment_option || 'full')}</div>
+                                <div><strong>Status:</strong> ${Utils.escapeHtml(registration.status)}</div>
                                 <div><strong>Submitted:</strong> ${new Date(registration.submitted_at).toLocaleString()}</div>
                             </div>
                         </div>

--- a/frontend/public/js/components/email-management.js
+++ b/frontend/public/js/components/email-management.js
@@ -391,8 +391,8 @@ window.EmailManagement = {
                                 <div id="email-groups-list" class="form-checkbox-group">
                                     ${this.availableGroups.map(group => `
                                         <label class="checkbox-item">
-                                            <input type="checkbox" name="target_groups" value="${group.name}">
-                                            <span class="checkbox-label">${group.name}</span>
+                                            <input type="checkbox" name="target_groups" value="${this.escapeHtml(group.name).replace(/"/g, '&quot;')}">
+                                            <span class="checkbox-label">${this.escapeHtml(group.name)}</span>
                                         </label>
                                     `).join('')}
                                 </div>

--- a/frontend/public/js/enhanced-session-management.js
+++ b/frontend/public/js/enhanced-session-management.js
@@ -638,8 +638,11 @@
             // Use session manager instead of direct localStorage
             SessionManager.setItem('token', token, type);
             
-            // Set expiration tracking
-            const expiresAt = Date.now() + (2 * 60 * 60 * 1000); // 2 hours
+            // Set expiration tracking. Must match the server token lifetime
+            // (TOKEN_EXPIRY_MS = 8h in functions/_shared/auth.ts). A shorter
+            // client-side window silently logs the user out mid-session even
+            // though the server token is still valid.
+            const expiresAt = Date.now() + (8 * 60 * 60 * 1000); // 8 hours
             SessionManager.setItem('token_expires', expiresAt, type);
             
             // Clear any conflict flags

--- a/functions/api/admin/activity-teams/index.ts
+++ b/functions/api/admin/activity-teams/index.ts
@@ -2,6 +2,7 @@ import type { PagesContext } from '../../../_shared/types.js';
 import { createResponse, checkAdminAuth, handleCORS } from '../../../_shared/auth.js';
 import { errors, createErrorResponse, generateRequestId, handleError } from '../../../_shared/errors.js';
 import { sendEmailsBulk, isEmailReady, type OutboundEmail } from '../../../_shared/email.js';
+import { escapeHtml } from '../../../_shared/sanitize.js';
 
 interface TeamRow {
   id: number;
@@ -174,13 +175,13 @@ async function sendTeamNotificationEmails(
                 <h1 style="color: white; margin: 0;">Activity Team Assignment</h1>
               </div>
               <div style="padding: 30px; background: #f8fafc; border-radius: 0 0 12px 12px;">
-                <p>Dear ${member.name},</p>
-                <p>You have been added to an activity team for the <strong>${retreatName}</strong>!</p>
+                <p>Dear ${escapeHtml(member.name)},</p>
+                <p>You have been added to an activity team for the <strong>${escapeHtml(retreatName)}</strong>!</p>
                 <div style="background: white; padding: 20px; border-radius: 8px; border-left: 4px solid #667eea; margin: 20px 0;">
-                  <p style="margin: 0 0 8px;"><strong>Team:</strong> ${teamName}</p>
-                  ${description ? `<p style="margin: 0 0 8px;"><strong>Description:</strong> ${description}</p>` : ''}
-                  <p style="margin: 0 0 8px;"><strong>Team Leader:</strong> ${leaderName}</p>
-                  <p style="margin: 0;"><strong>Team Members:</strong> ${memberNames.join(', ')}</p>
+                  <p style="margin: 0 0 8px;"><strong>Team:</strong> ${escapeHtml(teamName)}</p>
+                  ${description ? `<p style="margin: 0 0 8px;"><strong>Description:</strong> ${escapeHtml(description)}</p>` : ''}
+                  <p style="margin: 0 0 8px;"><strong>Team Leader:</strong> ${escapeHtml(leaderName)}</p>
+                  <p style="margin: 0;"><strong>Team Members:</strong> ${memberNames.map(escapeHtml).join(', ')}</p>
                 </div>
                 ${member.id === leaderId ? '<p style="color: #667eea; font-weight: 600;">You have been designated as the Team Leader!</p>' : ''}
                 <p>We look forward to a wonderful retreat experience together!</p>

--- a/functions/api/admin/change-password.ts
+++ b/functions/api/admin/change-password.ts
@@ -22,6 +22,8 @@ import {
   handleCORS,
   hashPassword,
   verifyPassword,
+  checkRateLimit,
+  recordLoginAttempt,
 } from '../../_shared/auth.js';
 import { errors, createErrorResponse, generateRequestId, handleError } from '../../_shared/errors.js';
 
@@ -58,6 +60,10 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
     if (next === current) {
       return createErrorResponse(errors.badRequest('New password must be different from current password', requestId));
     }
+
+    const clientIP = context.request.headers.get('CF-Connecting-IP') ||
+                     context.request.headers.get('X-Forwarded-For') ||
+                     'unknown';
 
     const hasAuthHeader = !!context.request.headers.get('Authorization');
     const secret = context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET;
@@ -107,6 +113,14 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
         return createErrorResponse(errors.forbidden('Password change requires authentication; use the normal change-password flow.', requestId));
       }
       isForcedResetPath = true;
+
+      // This path is unauthenticated and verifies the admin-set temp password
+      // below, so it's a brute-force surface — throttle it the same way login
+      // and the attendee change-password flow are (per-identifier + per-IP).
+      const rl = await checkRateLimit(context.env.DB, username, 'admin', clientIP);
+      if (!rl.allowed) {
+        return createErrorResponse(errors.rateLimited(Math.ceil((rl.resetTime - Date.now()) / 1000), requestId));
+      }
     }
 
     // Verify the current password.
@@ -124,6 +138,9 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
     }
 
     if (!currentValid) {
+      if (isForcedResetPath && resolvedUsername) {
+        await recordLoginAttempt(context.env.DB, resolvedUsername, 'admin', false, clientIP);
+      }
       return createErrorResponse(errors.unauthorized('Current password is incorrect', requestId));
     }
 
@@ -156,6 +173,10 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
       ).run();
     } catch (err) {
       console.warn(`[${requestId}] audit_log write failed`, err);
+    }
+
+    if (isForcedResetPath && resolvedUsername) {
+      await recordLoginAttempt(context.env.DB, resolvedUsername, 'admin', true, clientIP);
     }
 
     return createResponse({ success: true, message: 'Password updated' });

--- a/functions/api/admin/email/notifications.ts
+++ b/functions/api/admin/email/notifications.ts
@@ -5,6 +5,7 @@ import { createResponse, checkAdminAuth, handleCORS } from '../../../_shared/aut
 import { headerStyles, typeIcons } from '../../../_shared/email-helpers.js';
 import { errors, createErrorResponse, generateRequestId, handleError } from '../../../_shared/errors.js';
 import { sendEmail, isEmailReady } from '../../../_shared/email.js';
+import { escapeHtml } from '../../../_shared/sanitize.js';
 
 interface AttendeeRow {
   id: number;
@@ -306,18 +307,18 @@ function generateGenericTemplate(templateData: EmailTemplate, attendee: Attendee
   return `
     <div style="font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; max-width: 600px; margin: 0 auto; background: #f8fafc; padding: 2rem;">
       <div style="${headerStyle} color: white; padding: 2rem; text-align: center; border-radius: 12px 12px 0 0;">
-        <h1 style="margin: 0; font-size: 1.8rem;">${icon} ${templateData.subject}</h1>
+        <h1 style="margin: 0; font-size: 1.8rem;">${icon} ${escapeHtml(templateData.subject)}</h1>
         <p style="margin: 0.5rem 0 0 0; opacity: 0.9;">Growth and Wisdom Retreat Portal</p>
       </div>
 
       <div style="background: white; padding: 2rem; border-radius: 0 0 12px 12px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);">
         <div style="margin-bottom: 1.5rem;">
-          <h3 style="color: #1f2937; margin: 0 0 0.5rem 0;">Hello ${attendee.name}!</h3>
-          <p style="color: #6b7280; margin: 0; font-size: 0.9rem;">Reference: ${attendee.ref_number}</p>
+          <h3 style="color: #1f2937; margin: 0 0 0.5rem 0;">Hello ${escapeHtml(attendee.name)}!</h3>
+          <p style="color: #6b7280; margin: 0; font-size: 0.9rem;">Reference: ${escapeHtml(attendee.ref_number)}</p>
         </div>
 
         <div style="background: #f9fafb; padding: 1.5rem; border-radius: 8px; border-left: 4px solid #667eea; margin: 1.5rem 0;">
-          <div style="color: #374151; line-height: 1.6; white-space: pre-wrap;">${templateData.message}</div>
+          <div style="color: #374151; line-height: 1.6; white-space: pre-wrap;">${escapeHtml(templateData.message)}</div>
         </div>
 
         <div style="border-top: 1px solid #e5e7eb; padding-top: 1.5rem; margin-top: 2rem; color: #6b7280; font-size: 0.875rem; text-align: center;">


### PR DESCRIPTION
First batch from the codebase security review — five confirmed defects, all low-risk fixes (escaping, a rate-limit, and a constant). Type-checks clean. Payments correctness fixes will follow in a separate PR you can test against a real checkout.

## Fixes

**Stored XSS — admin "View Registration" modal** (`admin-dashboard.js`)
`registration.phone`, `emergency_contact`, `payment_option`, `status`, and each family member's `date_of_birth`/`member_type`/`dietary` come straight from the public `/api/register` form and were interpolated into `innerHTML` unescaped — markup in any field ran JS in the admin's authenticated session when they opened the modal. Now escaped (name/email/special_requests already were).

**Stored XSS — bulk-email modal** (`email-management.js`)
`group.name` went into a checkbox `value="…"` attribute and label with no escaping. Now escaped, with the attribute value additionally quote-guarded (the client `escapeHtml` doesn't escape quotes).

**Email HTML injection** (`email/notifications.ts`, `activity-teams/index.ts`)
The generic notification template and the activity-team assignment email interpolated subject, attendee name/ref, message, and team name/description/leader/member-names into HTML bodies unescaped. Now run through the shared `escapeHtml`, matching every other template.

**Admin forced-reset brute-force** (`admin/change-password.ts`)
The unauthenticated `must_reset_password` path verified the admin-set temp password with **no** rate limiting (the attendee flow has it). Added the same per-identifier + per-IP throttle and attempt logging, so a known username + weak temp password can't be brute-forced unthrottled.

**Premature logout** (`enhanced-session-management.js`)
The client expired its stored token after **2h** while the server token lasts **8h** (`auth.ts` `TOKEN_EXPIRY_MS`), bouncing admins to login mid-session with a still-valid token. Aligned the client to 8h. (Likely the "logged out" behavior reported.)

## Not included (tracked for follow-up PRs)
- **Payments**: family/group card payment charged but never credited (UNIQUE collision in the webhook) + duplicate-webhook double-credit — next PR, needs checkout testing.
- **Schema-drift**: `registrations.payment_option` and `announcements.email_sent` columns exist in prod but no migration creates them (a from-migrations rebuild / the new migrations CI would break) — migration-hygiene PR.
- Assorted Medium/Low (bulk-email reports success on 0-sent, `register.ts` Resend gating, pagination caps, `javascript:` link in announcements, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TM9EsRHSBTB4vMRKrRDrRB)_