### PR TITLE
fix(payments): credit family/group payments + idempotent webhook crediting

### DIFF
--- a/functions/api/webhooks/stripe.ts
+++ b/functions/api/webhooks/stripe.ts
@@ -133,14 +133,23 @@ async function handleCheckoutCompleted(
     }
   }
 
-  // Update payment record (find by checkout session ID)
-  await context.env.DB.prepare(`
+  // Flip the payment row to succeeded. The `status = 'pending'` guard makes
+  // this the authoritative idempotency point: only the invocation that
+  // actually transitions pending -> succeeded credits the balance below, so a
+  // duplicate or concurrent webhook delivery can't reduce payment_due twice
+  // (the PI check above only catches sequential re-delivery, not a race).
+  const upd = await context.env.DB.prepare(`
     UPDATE payments
     SET status = 'succeeded',
         stripe_payment_intent_id = ?,
         paid_at = CURRENT_TIMESTAMP
-    WHERE stripe_checkout_session_id = ? AND attendee_id = ?
+    WHERE stripe_checkout_session_id = ? AND attendee_id = ? AND status = 'pending'
   `).bind(paymentIntentId, session.id, attendeeId).run();
+
+  if (upd.meta.changes === 0) {
+    console.log(`[${requestId}] payment for session ${session.id} / attendee ${attendeeId} already finalised, skipping credit`);
+    return;
+  }
 
   // Reduce attendee's payment_due
   const paidPounds = penceToPounds(amountTotal);
@@ -224,15 +233,33 @@ async function handleGroupCheckoutCompleted(
     ? session.payment_intent
     : session.payment_intent?.id || null;
 
-  // Mark every row succeeded + tag with the PI for receipt traceability.
-  // Single UPDATE keyed on session id covers all family rows.
-  await context.env.DB.prepare(`
+  // Mark every family row succeeded. We deliberately do NOT write the PI in
+  // this multi-row UPDATE: payments.stripe_payment_intent_id is UNIQUE, and a
+  // group session has one row per member, so setting the same PI on all of
+  // them trips the UNIQUE constraint — which previously threw HERE, before any
+  // balance was credited, leaving the whole family charged-but-not-credited
+  // and the webhook stuck in a 500 retry loop. A single row is tagged with the
+  // PI afterwards for traceability. The rows-changed check below also keeps
+  // crediting idempotent against duplicate/concurrent deliveries.
+  const upd = await context.env.DB.prepare(`
     UPDATE payments
-    SET status = 'succeeded',
-        stripe_payment_intent_id = ?,
-        paid_at = CURRENT_TIMESTAMP
+    SET status = 'succeeded', paid_at = CURRENT_TIMESTAMP
     WHERE stripe_checkout_session_id = ? AND status = 'pending'
-  `).bind(paymentIntentId, session.id).run();
+  `).bind(session.id).run();
+
+  if (upd.meta.changes === 0) {
+    console.log(`[${requestId}] group session ${session.id} already credited, skipping`);
+    return;
+  }
+
+  // Tag exactly one row with the PI for receipt traceability (UNIQUE-safe).
+  if (paymentIntentId) {
+    await context.env.DB.prepare(`
+      UPDATE payments
+      SET stripe_payment_intent_id = ?
+      WHERE id = (SELECT MIN(id) FROM payments WHERE stripe_checkout_session_id = ?)
+    `).bind(paymentIntentId, session.id).run();
+  }
 
   // Credit each attendee's balance. We iterate rather than batch a
   // single SQL because each attendee has a distinct payment_due


### PR DESCRIPTION
Second batch from the review — the two confirmed Stripe-webhook money bugs. **Please test a real (test-mode) checkout before merging**, as I can't run the payment flow from here. Type-checks clean; change is isolated to `functions/api/webhooks/stripe.ts`.

## 1. CRITICAL — family/group payments charged but never credited

`handleGroupCheckoutCompleted` wrote the **same** `stripe_payment_intent_id` to every per-member `payments` row in one multi-row UPDATE. But that column is `UNIQUE` (`migrations/009_payments.sql:7`), and a group session has one row per family member (`group/checkout.ts:99-111`). So for **any family of 2+**, the second row trips the constraint, the handler throws *before* the balance-credit batch, and Stripe retries the resulting 500 indefinitely — **the family is debited while every balance stays fully outstanding.**

Fix: the multi-row UPDATE now marks rows `succeeded` **without** the PI; a single representative row is tagged with the PI afterwards for receipt traceability. The `UNIQUE` constraint is never violated, so balances credit correctly.

## 2. HIGH — duplicate/concurrent webhook can double-credit

The single-payment credit was a read-modify-write (`SELECT payment_due` → `UPDATE … = max(0, due - paid)`) guarded only by a pre-read PI check. Stripe delivers events at-least-once; two concurrent duplicates both pass the pre-read guard and both credit, reducing `payment_due` twice for one payment.

Fix: both the single-payment and group paths now gate crediting on the **rows-changed count** of a `status = 'pending'` UPDATE. Only the invocation that actually transitions the row `pending → succeeded` proceeds to credit, so duplicates are no-ops. (As a bonus, the single-payment path no longer credits at all when no matching *pending* row exists — defends against crediting for sessions we didn't create.)

## How to verify
- **Group:** in Stripe test mode, run a family/group checkout for 2+ members → confirm all balances drop and the webhook returns 200 (previously 500 + retries).
- **Single:** complete one checkout → balance reduces once. Re-deliver the same `checkout.session.completed` from the Stripe dashboard → balance does **not** reduce again.

## Not included
The flexible-installment path (`handleFlexibleInstallmentCompleted`) uses the same pre-read-guard pattern and could be hardened identically; left out to keep this PR scoped to the two confirmed findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TM9EsRHSBTB4vMRKrRDrRB)_