### PR TITLE
fix(email): email-reliability batch + 024 migration apply hotfix

### DIFF
--- a/frontend/public/js/components/email-management.js
+++ b/frontend/public/js/components/email-management.js
@@ -589,16 +589,30 @@ This message will be formatted nicely and include attendee-specific details like
 
             // Send email via API
             const response = await API.post('/admin/email/send', formData);
-            
-            this.showModalAlert('bulk-email-alert', 
-                `Emails sent successfully to ${response.results.successful} attendees!`, 
+            const r = response.results || {};
+            const sent = r.successful || 0;
+            const failed = r.failed || 0;
+
+            // Don't claim success when nothing actually sent (e.g. unverified
+            // sender domain → every delivery failed but the request returned).
+            if (sent === 0) {
+                this.showModalAlert('bulk-email-alert',
+                    response.message || `Email delivery failed — 0 of ${r.total || 0} sent.`,
+                    'error'
+                );
+                return;
+            }
+
+            const note = failed > 0 ? ` (${failed} failed)` : '';
+            this.showModalAlert('bulk-email-alert',
+                `Emails sent to ${sent} of ${r.total} attendees${note}.`,
                 'success'
             );
 
             // Auto-close modal after success
             setTimeout(() => {
                 this.closeAllModals();
-                Utils.showAlert(`Bulk email sent to ${response.results.successful} attendees!`, 'success');
+                Utils.showAlert(`Bulk email sent to ${sent} attendees${note}.`, 'success');
             }, 2000);
 
         } catch (error) {

--- a/functions/api/admin/announcements/[id]/email.ts
+++ b/functions/api/admin/announcements/[id]/email.ts
@@ -110,16 +110,31 @@ export async function onRequestPost(context: PagesContext<IdParams>): Promise<Re
       adminUser: admin.user || 'Admin'
     });
 
-    // Update announcement to mark as emailed
-    await context.env.DB.prepare(`
-      UPDATE announcements
-      SET email_sent = 1, email_sent_at = CURRENT_TIMESTAMP
-      WHERE id = ?
-    `).bind(announcementId).run();
+    const sent = emailResults.successful;
+    const allFailed = sent === 0 && emailResults.failed > 0;
+
+    // Only mark the announcement emailed if at least one message actually went
+    // out — and treat the tracking write as best-effort so a DB missing the
+    // email_sent columns (migration 024) doesn't fail the whole send.
+    if (sent > 0) {
+      try {
+        await context.env.DB.prepare(`
+          UPDATE announcements
+          SET email_sent = 1, email_sent_at = CURRENT_TIMESTAMP
+          WHERE id = ?
+        `).bind(announcementId).run();
+      } catch (err) {
+        console.warn(`[${requestId}] failed to mark announcement ${announcementId} emailed`, err);
+      }
+    }
 
     return createResponse({
-      success: true,
-      message: `Announcement emailed to ${emailResults.successful} attendees`,
+      success: !allFailed,
+      message: allFailed
+        ? `Announcement email delivery failed for all ${emailResults.failed} recipient(s).`
+        : emailResults.failed > 0
+          ? `Announcement emailed to ${sent} attendee(s); ${emailResults.failed} failed.`
+          : `Announcement emailed to ${sent} attendee(s).`,
       results: emailResults
     });
 

--- a/functions/api/admin/email/send.ts
+++ b/functions/api/admin/email/send.ts
@@ -88,13 +88,25 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
       sender: 'The Growth and Wisdom Retreat Team'
     });
 
+    // Report the real delivery outcome. Previously this always returned
+    // success:true with "sent to N attendees" even when N was 0 (every send
+    // failed — e.g. unverified sender domain), so a totally broken blast
+    // looked successful to the admin.
+    const sent = emailResults.successful;
+    const failed = emailResults.failed;
+    const allFailed = sent === 0 && attendees.length > 0;
+
     return createResponse({
-      success: true,
-      message: `Emails sent to ${emailResults.successful} attendees`,
+      success: !allFailed,
+      message: allFailed
+        ? `Delivery failed for all ${attendees.length} recipient(s)${emailResults.errors?.[0] ? `: ${emailResults.errors[0]}` : '. Check the email service configuration.'}`
+        : failed > 0
+          ? `Sent to ${sent} of ${attendees.length}; ${failed} failed${emailResults.errors?.[0] ? ` (${emailResults.errors[0]})` : ''}.`
+          : `Emails sent to ${sent} attendee(s).`,
       results: {
         total: attendees.length,
-        successful: emailResults.successful,
-        failed: emailResults.failed,
+        successful: sent,
+        failed,
         errors: emailResults.errors
       }
     });

--- a/functions/api/register.ts
+++ b/functions/api/register.ts
@@ -5,7 +5,7 @@ import type { PagesContext, Env } from '../_shared/types.js';
 import { createResponse, handleCORS } from '../_shared/auth.js';
 import { errors, createErrorResponse, generateRequestId, handleError } from '../_shared/errors.js';
 import { escapeHtml } from '../_shared/sanitize.js';
-import { sendEmailOrThrow } from '../_shared/email.js';
+import { sendEmailOrThrow, isEmailReady } from '../_shared/email.js';
 
 // Pricing constants
 const PRICING = {
@@ -286,7 +286,7 @@ async function sendRegistrationNotification(
   data: RegistrationInput,
   registrationId: number
 ): Promise<void> {
-  if (!env.EMAIL || !env.FROM_EMAIL) {
+  if (!isEmailReady(env)) {
     console.warn('Email service not configured - skipping notification');
     return;
   }

--- a/migrations/024_announcement_email_tracking.sql
+++ b/migrations/024_announcement_email_tracking.sql
@@ -1,25 +1,25 @@
 /* Track which announcements have been emailed to attendees.
 
    functions/api/admin/announcements/[id]/email.ts marks an announcement
-   with `email_sent = 1, email_sent_at = CURRENT_TIMESTAMP` after sending,
-   but migration 016 (which creates the announcements table) never added
-   those columns. A database built purely from migrations therefore 500s on
-   that endpoint, and a from-scratch build is missing them. This adds them.
+   email_sent = 1 with email_sent_at = CURRENT_TIMESTAMP after sending, but
+   migration 016 (which creates the announcements table) never added those
+   columns. A database lacking them fails when an announcement is emailed.
+   This adds them.
 
-   Unlike the registrations.payment_option fix (folded into 007 because 008
+   Unlike the registrations.payment_option gap (folded into 007 because 008
    depends on it), nothing reads these columns at migration time, so a new
    migration is the right home.
 
    PRODUCTION NOTE: if these columns were already added to prod by hand,
-   applying this migration there will fail with "duplicate column name". In
-   that case record it as already-applied instead of running it — add
-   '024_announcement_email_tracking.sql' to scripts/baseline-d1-migrations.sql.
-   Check first with:
-     SELECT name FROM pragma_table_info('announcements')
-     WHERE name IN ('email_sent','email_sent_at');
-   See migrations/README.md ("Reconciling pre-existing schema drift").
+   applying this migration there fails with a duplicate-column error. In that
+   case record it as already-applied instead, by adding the file name to
+   scripts/baseline-d1-migrations.sql. See migrations/README.md, section
+   "Known limitation: the 001-023 history is not cleanly re-appliable".
 
-   Block comments only, one ALTER per statement — D1-console safe. */
+   IMPORTANT: no semicolons anywhere in this comment block. wrangler/D1 splits
+   migrations on the semicolon, so a semicolon inside a comment splits the file
+   mid-comment and the apply fails with "SQL code did not contain a statement".
+   Block comments only, one ALTER per statement. */
 
 ALTER TABLE announcements ADD COLUMN email_sent INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE announcements ADD COLUMN email_sent_at DATETIME;


### PR DESCRIPTION
Two commits:

## 1. Migration `024` apply hotfix (added)
The `024` migration (merged in #29) **failed to apply** via `wrangler d1 migrations apply` with `SQL code did not contain a statement` (D1 7500). Cause: its block comment contained an example query ending in a **semicolon**, and D1 splits migrations on `;`, so it split mid-comment and left an unterminated `/* …` with no statement. The run rolls back, so nothing was harmed. Rewrote the comment semicolon-free; the two `ALTER`s are unchanged. **After this merges, re-run the D1 migrations workflow and `024` will apply.**

## 2. Email reliability — sends that *look* like they worked but didn't
**Bulk send reported success even when nothing sent** (`admin/email/send.ts` + `email-management.js`) — returned `success:true` / "sent to N attendees" even when N was 0 (e.g. unverified sender domain), so a totally failed blast showed green. Now returns `success:false` + a clear failure message when all failed, a partial count when some failed; the UI shows an error alert on a 0-sent result.

**Announcement email faked success + could 500** (`announcements/[id]/email.ts`) — marked `email_sent=1` and reported success even on 0 sent. Now only marks sent when ≥1 went out, reports the real outcome, and makes the `email_sent` write best-effort so a DB missing those columns can't fail the send.

**New-registration admin alerts skipped on Resend-only** (`register.ts`) — gated on `!env.EMAIL`, so a Resend-only deployment never emailed admins. Switched to `isEmailReady(env)`.

Type-checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)