### PR TITLE
test: fix 12 stale tests + add a test-running CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+# Runs the type-check and the vitest suite on every PR and on pushes to main,
+# so a regression (or a test drifting from the code, as 12 had) fails the PR
+# instead of rotting silently. The Cloudflare Pages check only builds/deploys —
+# it does not run the tests.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      # The repo vendors node_modules with platform-specific (Windows) binaries.
+      # `npm ci` wipes and reinstalls them for this Linux runner so vitest's
+      # workerd pool can start.
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,6 +1,6 @@
 // Tests for authentication utilities
 import { describe, it, expect } from 'vitest';
-import { hashPassword, verifyPassword, needsPasswordUpgrade } from '../functions/_shared/auth.js';
+import { hashPassword, verifyPassword } from '../functions/_shared/auth.js';
 
 describe('Authentication Utilities', () => {
   describe('hashPassword', () => {
@@ -55,22 +55,6 @@ describe('Authentication Utilities', () => {
       const hash = await hashPassword(password);
       const isValid = await verifyPassword(password, hash);
       expect(isValid).toBe(true);
-    });
-  });
-
-  describe('needsPasswordUpgrade', () => {
-    it('should return true for old bcrypt-style hashes', () => {
-      const oldHash = '$2b$10$somehashvalue';
-      expect(needsPasswordUpgrade(oldHash)).toBe(true);
-    });
-
-    it('should return false for new PBKDF2 hashes', async () => {
-      const newHash = await hashPassword('testpassword');
-      expect(needsPasswordUpgrade(newHash)).toBe(false);
-    });
-
-    it('should return true for plain text passwords', () => {
-      expect(needsPasswordUpgrade('plainpassword')).toBe(true);
     });
   });
 

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,6 +1,6 @@
 // Tests for error handling utilities
 import { describe, it, expect } from 'vitest';
-import { errors, createErrorResponse, generateRequestId, handleError, AppError } from '../functions/_shared/errors.js';
+import { errors, createErrorResponse, generateRequestId, handleError, AppError, ErrorCode } from '../functions/_shared/errors.js';
 
 describe('Error Handling Utilities', () => {
   describe('generateRequestId', () => {
@@ -31,7 +31,7 @@ describe('Error Handling Utilities', () => {
         expect(error.code).toBe('VALIDATION_ERROR');
         expect(error.status).toBe(400);
         expect(error.details.fields).toEqual(fieldErrors);
-        expect(error.details.requestId).toBe('req_123');
+        expect(error.requestId).toBe('req_123');
       });
     });
 
@@ -42,7 +42,7 @@ describe('Error Handling Utilities', () => {
         expect(error.code).toBe('UNAUTHORIZED');
         expect(error.status).toBe(401);
         expect(error.message).toBe('Token expired');
-        expect(error.details.requestId).toBe('req_456');
+        expect(error.requestId).toBe('req_456');
       });
     });
 
@@ -53,7 +53,7 @@ describe('Error Handling Utilities', () => {
         expect(error.code).toBe('NOT_FOUND');
         expect(error.status).toBe(404);
         expect(error.message).toBe('Attendee not found');
-        expect(error.details.requestId).toBe('req_789');
+        expect(error.requestId).toBe('req_789');
       });
     });
 
@@ -143,24 +143,25 @@ describe('Error Handling Utilities', () => {
       const error = new Error('Test');
       const result = handleError(error, 'req_custom');
 
-      expect(result.details.requestId).toBe('req_custom');
+      expect(result.requestId).toBe('req_custom');
     });
   });
 
   describe('AppError class', () => {
     it('should extend Error', () => {
-      const appError = new AppError('Test', 'TEST_CODE', 400, {});
+      const appError = new AppError(ErrorCode.INTERNAL_ERROR, 'Test');
       expect(appError instanceof Error).toBe(true);
     });
 
     it('should have correct properties', () => {
       const details = { field: 'value' };
-      const appError = new AppError('Test message', 'CUSTOM_CODE', 418, details);
+      const appError = new AppError(ErrorCode.NOT_FOUND, 'Test message', details, 'req_x');
 
       expect(appError.message).toBe('Test message');
-      expect(appError.code).toBe('CUSTOM_CODE');
-      expect(appError.status).toBe(418);
+      expect(appError.code).toBe(ErrorCode.NOT_FOUND);
+      expect(appError.status).toBe(404); // status is derived from the code
       expect(appError.details).toEqual(details);
+      expect(appError.requestId).toBe('req_x');
     });
   });
 });

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -24,10 +24,10 @@ describe('Pagination Utilities', () => {
       expect(result.limit).toBe(500);
     });
 
-    it('should enforce minimum limit of 1', () => {
+    it('should fall back to the default limit when below the minimum', () => {
       const url = new URL('https://example.com/api/items?limit=0');
       const result = parsePaginationParams(url);
-      expect(result.limit).toBe(1);
+      expect(result.limit).toBe(50); // sub-minimum limit resets to DEFAULT_LIMIT
     });
 
     it('should enforce non-negative offset', () => {
@@ -43,10 +43,10 @@ describe('Pagination Utilities', () => {
       expect(result.offset).toBe(0); // default
     });
 
-    it('should parse page parameter and calculate offset', () => {
-      const url = new URL('https://example.com/api/items?page=3&limit=10');
+    it('should parse offset and limit from query params', () => {
+      const url = new URL('https://example.com/api/items?offset=20&limit=10');
       const result = parsePaginationParams(url);
-      expect(result.offset).toBe(20); // (page - 1) * limit = (3 - 1) * 10
+      expect(result.offset).toBe(20);
       expect(result.limit).toBe(10);
     });
   });

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,6 +1,6 @@
 // Tests for validation utilities
 import { describe, it, expect } from 'vitest';
-import { validate, attendeeCreateSchema, roomCreateSchema, groupSchema, announcementCreateSchema } from '../functions/_shared/validation.js';
+import { validate, attendeeCreateSchema, roomCreateSchema, groupCreateSchema, announcementCreateSchema } from '../functions/_shared/validation.js';
 
 describe('Validation Utilities', () => {
   describe('validate function', () => {
@@ -81,16 +81,16 @@ describe('Validation Utilities', () => {
     });
   });
 
-  describe('groupSchema', () => {
+  describe('groupCreateSchema', () => {
     it('should validate valid group data', () => {
       const data = { name: 'VIP Group' };
-      const result = validate(data, groupSchema);
+      const result = validate(data, groupCreateSchema);
       expect(result.valid).toBe(true);
     });
 
     it('should reject empty group name', () => {
       const data = { name: '' };
-      const result = validate(data, groupSchema);
+      const result = validate(data, groupCreateSchema);
       expect(result.valid).toBe(false);
       expect(result.errors.name).toBeDefined();
     });


### PR DESCRIPTION
Two related commits — make the suite green, then **enforce** it so it can't silently rot again.

## 1. Fix 12 stale tests (`e3b654a`)
All 12 failures were tests written against earlier APIs — **none were real bugs**:

| File | Cause | Fix |
|------|-------|-----|
| `validation` | imported `groupSchema` (renamed `groupCreateSchema`) | use the real export |
| `auth` | tested `needsPasswordUpgrade`, removed with legacy `$retreat$` hashing | dropped the obsolete tests |
| `errors` | checked `error.details.requestId` (it's top-level `error.requestId`; only the serialized `toJSON` nests it) + old `AppError(message, code, status, details)` signature (real: `(code, message, details?, requestId?)`, status derived) | check `error.requestId`; use the real constructor |
| `pagination` | expected a `page` param (helper is offset-based) + clamp-to-1 (code falls back to default) | test the actual offset-based contract |

Tests aligned to the production code; no application behavior changed. Local result: **57 passing**.

## 2. Add CI (`51c195d`)
`.github/workflows/ci.yml` runs **`npm run typecheck` + `npm test`** on every PR and push to `main`. The Cloudflare Pages check only builds/deploys — the suite was never enforced, which is exactly how those 12 tests drifted unnoticed. Uses `npm ci` because the repo vendors `node_modules` with Windows binaries and the Linux runner needs a clean install for vitest's workerd pool.

The new **CI** check on this PR runs against the fixed tests, so it should land green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)