### PR TITLE
feat(program): admin-managed retreat program (DB-backed schedule)

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -74,6 +74,7 @@
     <script src="js/components/group-management.js"></script>
     <script src="js/components/activity-team-management.js"></script>
     <script src="js/components/announcement-management.js"></script>
+    <script src="js/components/program-management.js"></script>
     <script src="js/components/bulk-upload.js"></script>
     <script src="js/components/email-management.js"></script>
     <script src="js/components/check-in-management.js"></script>

--- a/frontend/public/js/components/admin-dashboard.js
+++ b/frontend/public/js/components/admin-dashboard.js
@@ -5,6 +5,7 @@ const AdminDashboard = {
         rooms: [],
         groups: [],
         announcements: [],
+        program: [],
         registrations: [],
         loginHistory: [],
         payments: [],
@@ -270,6 +271,7 @@ const AdminDashboard = {
         rooms: false,
         groups: false,
         announcements: false,
+        program: false,
         registrations: false,
         loginHistory: false
     },
@@ -288,6 +290,7 @@ const AdminDashboard = {
             this.loadRooms(),
             this.loadGroups(),
             this.loadAnnouncements(),
+            this.loadProgram(),
             this.loadRegistrations(),
             this.loadLoginHistory()
         ]);
@@ -411,6 +414,32 @@ const AdminDashboard = {
     },
 
     /**
+     * Load program data with loading state
+     */
+    async loadProgram() {
+        const tableBody = 'program-table-body';
+        this.loadingStates.program = true;
+        Utils.showSectionLoading(tableBody, 'Loading program...');
+
+        try {
+            const response = await API.get('/admin/program');
+            this.data.program = response.items || response.data || response;
+            this.loadingStates.program = false;
+            this.failedLoads.delete('program');
+            console.log('Loaded program:', this.data.program.length);
+        } catch (error) {
+            console.error('Failed to load program:', error);
+            this.data.program = [];
+            this.loadingStates.program = false;
+            this.failedLoads.add('program');
+            Utils.showSectionError(tableBody, 'Failed to load program', () => {
+                this.loadProgram().then(() => this.updateProgramDisplay());
+            });
+            throw error;
+        }
+    },
+
+    /**
      * Load registrations data with loading state
      */
     async loadRegistrations(status = 'pending') {
@@ -497,6 +526,7 @@ const AdminDashboard = {
         this.updateAttendeesDisplay();
         this.updateRegistrationsDisplay();
         this.updateAnnouncementsDisplay();
+        this.updateProgramDisplay();
         this.updateRoomsDisplay();
         this.updateGroupsDisplay();
         this.updateLoginHistoryDisplay();
@@ -818,6 +848,46 @@ const AdminDashboard = {
                                 <i class="fas fa-${announcement.is_active ? 'eye-slash' : 'eye'}"></i>
                             </button>
                             <button class="btn btn-sm btn-danger delete-announcement" data-id="${announcement.id}" title="Delete Announcement">
+                                <i class="fas fa-trash"></i>
+                            </button>
+                        </div>
+                    </td>
+                </tr>
+            `;
+        }).join('');
+    },
+
+    /**
+     * Update program table display
+     */
+    updateProgramDisplay() {
+        const tbody = document.getElementById('program-table-body');
+        if (!tbody) return;
+
+        if (this.data.program.length === 0) {
+            tbody.innerHTML = `
+                <tr>
+                    <td colspan="5" style="text-align: center; color: var(--text-secondary); padding: 2rem;">
+                        No program items found
+                    </td>
+                </tr>
+            `;
+            return;
+        }
+
+        tbody.innerHTML = this.data.program.map(item => {
+            return `
+                <tr data-program-id="${item.id}">
+                    <td><strong>${Utils.escapeHtml(item.day_label)}</strong></td>
+                    <td>${item.time_label ? Utils.escapeHtml(item.time_label) : '<span style="color: var(--text-tertiary);">-</span>'}</td>
+                    <td>${Utils.escapeHtml(item.title)}</td>
+                    <td>${item.location ? Utils.escapeHtml(item.location) : '<span style="color: var(--text-tertiary);">-</span>'}</td>
+                    <td>
+                        <div class="action-buttons">
+                            <button class="btn btn-sm btn-primary edit-program" data-id="${item.id}" title="Edit Program Item">
+                                <i class="fas fa-edit"></i>
+                            </button>
+                            <button class="btn btn-sm btn-danger delete-program" data-id="${item.id}" title="Delete Program Item">
                                 <i class="fas fa-trash"></i>
                             </button>
                         </div>
@@ -1612,6 +1682,12 @@ const AdminDashboard = {
             addAnnouncementBtn.addEventListener('click', () => this.showAddAnnouncementModal());
         }
 
+        // Add program button
+        const addProgramBtn = document.getElementById('add-program-btn');
+        if (addProgramBtn) {
+            addProgramBtn.addEventListener('click', () => this.showAddProgramModal());
+        }
+
         // Add room button
         const addRoomBtn = document.getElementById('add-room-btn');
         if (addRoomBtn) {
@@ -1751,6 +1827,10 @@ const AdminDashboard = {
                 await this.toggleAnnouncement(id);
             } else if (target.classList.contains('delete-announcement')) {
                 await this.deleteAnnouncement(id);
+            } else if (target.classList.contains('edit-program')) {
+                await this.editProgram(id);
+            } else if (target.classList.contains('delete-program')) {
+                await this.deleteProgram(id);
             } else if (target.classList.contains('edit-room')) {
                 await this.editRoom(id);
             } else if (target.classList.contains('delete-room')) {
@@ -1870,6 +1950,14 @@ const AdminDashboard = {
         }
     },
 
+    async showAddProgramModal() {
+        if (window.ProgramManagement) {
+            await window.ProgramManagement.showModal(null);
+        } else {
+            Utils.showAlert('Program management component not loaded', 'error');
+        }
+    },
+
     async showAddRoomModal() {
         if (window.RoomManagement) {
             await window.RoomManagement.showModal();
@@ -1982,6 +2070,19 @@ const AdminDashboard = {
         }
     },
 
+    async editProgram(id) {
+        try {
+            const item = this.data.program.find(p => p.id == id);
+            if (item && window.ProgramManagement) {
+                await window.ProgramManagement.showModal(item);
+            } else {
+                Utils.showAlert('Program management component not loaded', 'error');
+            }
+        } catch (error) {
+            Utils.showAlert('Failed to load program details: ' + error.message, 'error');
+        }
+    },
+
     async editRoom(id) {
         try {
             const room = this.data.rooms.find(r => r.id == id);
@@ -2067,6 +2168,27 @@ const AdminDashboard = {
         } catch (error) {
             Utils.hideGlobalLoading();
             Utils.showAlert('Failed to delete announcement: ' + error.message, 'error');
+        }
+    },
+
+    async deleteProgram(id) {
+        const item = this.data.program.find(p => p.id == id);
+        if (!item) return;
+
+        if (!confirm(`Are you sure you want to delete "${item.title}"? This action cannot be undone.`)) {
+            return;
+        }
+
+        Utils.showGlobalLoading('Deleting program item...');
+        try {
+            await API.delete('/admin/program/' + id);
+            Utils.hideGlobalLoading();
+            Utils.showAlert('Program item deleted successfully', 'success');
+            await this.loadProgram();
+            this.updateProgramDisplay();
+        } catch (error) {
+            Utils.hideGlobalLoading();
+            Utils.showAlert('Failed to delete program item: ' + error.message, 'error');
         }
     },
 

--- a/frontend/public/js/components/attendee-dashboard.js
+++ b/frontend/public/js/components/attendee-dashboard.js
@@ -259,6 +259,60 @@ const AttendeeDashboard = {
         // Lazy-load per-view data.
         if (name === 'family') this.loadFamilyView();
         if (name === 'my-details') this.renderMyDetailsView();
+        if (name === 'schedule') this.loadSchedule();
+    },
+
+    /**
+     * Load the retreat schedule from the public program API and render it
+     * into #schedule-content, grouped by day (preserving server order).
+     * Mirrors the original hardcoded visual style.
+     */
+    async loadSchedule() {
+        const container = document.getElementById('schedule-content');
+        if (!container) return;
+
+        try {
+            const res = await API.get('/program');
+            const items = (res && res.items) || [];
+
+            if (items.length === 0) {
+                container.innerHTML = '<div style="color: var(--text-tertiary);"><i class="fas fa-calendar-day"></i> The schedule will be published soon.</div>';
+                return;
+            }
+
+            // Group by day_label, preserving first-seen order.
+            const order = [];
+            const groups = {};
+            items.forEach((item) => {
+                const day = item.day_label || '';
+                if (!(day in groups)) {
+                    groups[day] = [];
+                    order.push(day);
+                }
+                groups[day].push(item);
+            });
+
+            container.innerHTML = order.map((day, idx) => {
+                const rows = groups[day].map((item) => {
+                    const time = item.time_label ? `${this._escape(item.time_label)} — ` : '';
+                    const loc = item.location ? ` · ${this._escape(item.location)}` : '';
+                    const desc = item.description
+                        ? `<br><span style="color: var(--text-tertiary); font-size: 0.8rem;">${this._escape(item.description)}</span>`
+                        : '';
+                    return `${time}${this._escape(item.title)}${loc}${desc}`;
+                }).join('<br>');
+
+                const spacing = idx < order.length - 1 ? ' style="margin-bottom: 1rem;"' : '';
+                return `
+                    <div${spacing}>
+                        <div style="font-weight: 600; color: #5eead4; margin-bottom: 0.3rem;">${this._escape(day)}</div>
+                        <div style="color: var(--text-secondary); line-height: 1.6;">${rows}</div>
+                    </div>
+                `;
+            }).join('');
+        } catch (err) {
+            container.innerHTML = `<div style="color: var(--text-tertiary);">Failed to load schedule: ${this._escape(err.message || '')}</div>`;
+        }
     },
 
     async loadFamilyView() {

--- a/frontend/public/js/components/program-management.js
+++ b/frontend/public/js/components/program-management.js
@@ -1,0 +1,320 @@
+// frontend/public/js/components/program-management.js
+const ProgramManagement = {
+    isEditing: false,
+    editingId: null,
+
+    /**
+     * Show program item modal
+     */
+    async showModal(editData = null) {
+        this.isEditing = !!editData;
+        this.editingId = editData?.id || null;
+
+        try {
+            await this.renderModal();
+            this.populateForm(editData);
+            this.bindEvents();
+        } catch (error) {
+            console.error('Failed to show program modal:', error);
+            Utils.showAlert('Failed to load program form', 'error');
+        }
+    },
+
+    /**
+     * Render modal template
+     */
+    async renderModal() {
+        const modalHtml = `
+            <div class="modal-overlay" id="program-modal">
+                <div class="modal">
+                    <div class="modal-header">
+                        <h3 class="modal-title" id="program-modal-title">Add Program Item</h3>
+                        <button type="button" class="modal-close" id="close-program-modal">
+                            <i class="fas fa-times"></i>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <div id="program-modal-alert" class="alert alert-error hidden"></div>
+                        <form id="program-form">
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="program-day" class="form-label">
+                                        <i class="fas fa-calendar-day"></i> Day
+                                    </label>
+                                    <input type="text" id="program-day" name="day_label" class="form-input" required
+                                           placeholder="e.g., Fri, July 31">
+                                </div>
+
+                                <div class="form-group">
+                                    <label for="program-time" class="form-label">
+                                        <i class="fas fa-clock"></i> Time
+                                    </label>
+                                    <input type="text" id="program-time" name="time_label" class="form-input"
+                                           placeholder="e.g., 3:00 PM">
+                                </div>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="program-title" class="form-label">
+                                    <i class="fas fa-heading"></i> Title
+                                </label>
+                                <input type="text" id="program-title" name="title" class="form-input" required
+                                       placeholder="e.g., Welcome Session">
+                            </div>
+
+                            <div class="form-group">
+                                <label for="program-location" class="form-label">
+                                    <i class="fas fa-location-dot"></i> Location (Optional)
+                                </label>
+                                <input type="text" id="program-location" name="location" class="form-input"
+                                       placeholder="e.g., Main Hall">
+                            </div>
+
+                            <div class="form-group">
+                                <label for="program-description" class="form-label">
+                                    <i class="fas fa-edit"></i> Description (Optional)
+                                </label>
+                                <textarea id="program-description" name="description" class="form-input" rows="3"
+                                          placeholder="Additional details about this item..."></textarea>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="program-order" class="form-label">
+                                    <i class="fas fa-sort-numeric-down"></i> Order (Optional)
+                                </label>
+                                <input type="number" id="program-order" name="sort_order" class="form-input" min="0">
+                                <small class="form-help">Leave blank to append to the end of the list</small>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" id="cancel-program-modal">Cancel</button>
+                        <button type="submit" form="program-form" class="btn btn-primary" id="save-program">
+                            <span>Save Program Item</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        // Remove existing modal if present
+        const existingModal = document.getElementById('program-modal');
+        if (existingModal) {
+            existingModal.remove();
+        }
+
+        // Add modal to body
+        document.body.insertAdjacentHTML('beforeend', modalHtml);
+
+        // Show modal
+        document.getElementById('program-modal').classList.remove('hidden');
+    },
+
+    /**
+     * Populate form with data
+     */
+    populateForm(editData) {
+        // Update modal title
+        const title = this.isEditing ? 'Edit Program Item' : 'Add Program Item';
+        document.getElementById('program-modal-title').textContent = title;
+
+        // Fill form if editing
+        if (editData) {
+            document.getElementById('program-day').value = editData.day_label || '';
+            document.getElementById('program-time').value = editData.time_label || '';
+            document.getElementById('program-title').value = editData.title || '';
+            document.getElementById('program-location').value = editData.location || '';
+            document.getElementById('program-description').value = editData.description || '';
+            document.getElementById('program-order').value =
+                editData.sort_order != null ? editData.sort_order : '';
+        } else {
+            document.getElementById('program-form').reset();
+        }
+    },
+
+    /**
+     * Bind event listeners
+     */
+    bindEvents() {
+        // Form submission
+        document.getElementById('program-form').addEventListener('submit', this.handleSubmit.bind(this));
+
+        // Close buttons
+        document.getElementById('close-program-modal').addEventListener('click', this.hideModal.bind(this));
+        document.getElementById('cancel-program-modal').addEventListener('click', this.hideModal.bind(this));
+
+        // Close on overlay click
+        document.getElementById('program-modal').addEventListener('click', (e) => {
+            if (e.target.id === 'program-modal') {
+                this.hideModal();
+            }
+        });
+
+        // Escape key to close — keep the bound reference so removeEventListener works.
+        this._boundHandleKeyDown = this._boundHandleKeyDown || this.handleKeyDown.bind(this);
+        document.addEventListener('keydown', this._boundHandleKeyDown);
+    },
+
+    /**
+     * Handle form submission
+     */
+    async handleSubmit(e) {
+        e.preventDefault();
+
+        if (!this.validateForm()) {
+            return;
+        }
+
+        const formData = new FormData(e.target);
+        const data = Object.fromEntries(formData.entries());
+
+        // Trim text fields; drop empty optionals so the backend defaults apply.
+        ['day_label', 'time_label', 'title', 'location', 'description'].forEach(field => {
+            if (typeof data[field] === 'string') {
+                data[field] = data[field].trim();
+            }
+        });
+        ['time_label', 'location', 'description'].forEach(field => {
+            if (!data[field]) delete data[field];
+        });
+
+        // sort_order: send as number when provided, otherwise omit so it
+        // auto-appends to the end server-side.
+        if (data.sort_order === '' || data.sort_order == null) {
+            delete data.sort_order;
+        } else {
+            data.sort_order = parseInt(data.sort_order, 10);
+        }
+
+        const submitBtn = document.getElementById('save-program');
+
+        try {
+            Utils.showLoading(submitBtn);
+
+            if (this.isEditing) {
+                await API.put('/admin/program/' + this.editingId, data);
+            } else {
+                await API.post('/admin/program', data);
+            }
+
+            const action = this.isEditing ? 'updated' : 'created';
+            Utils.showAlert(`Program item ${action} successfully`, 'success');
+
+            this.hideModal();
+
+            // Refresh admin dashboard list if available
+            if (window.AdminDashboard) {
+                await window.AdminDashboard.loadProgram()
+                    .then(() => window.AdminDashboard.updateProgramDisplay())
+                    .catch(() => {});
+            }
+        } catch (error) {
+            this.showAlert(error.message, 'error');
+        } finally {
+            Utils.hideLoading(submitBtn);
+        }
+    },
+
+    /**
+     * Validate form
+     */
+    validateForm() {
+        let isValid = true;
+
+        // Clear previous alerts
+        this.hideAlert();
+
+        // Required fields
+        const requiredFields = [
+            { id: 'program-day', name: 'Day' },
+            { id: 'program-title', name: 'Title' }
+        ];
+
+        requiredFields.forEach(field => {
+            const input = document.getElementById(field.id);
+            if (!input.value.trim()) {
+                this.showFieldError(input, `${field.name} is required`);
+                isValid = false;
+            } else {
+                this.clearFieldError(input);
+            }
+        });
+
+        return isValid;
+    },
+
+    /**
+     * Utility methods
+     */
+    escapeHtml(value) {
+        return String(value ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    },
+
+    showFieldError(input, message) {
+        input.classList.add('invalid');
+
+        const existingError = input.parentNode.querySelector('.form-validation-message');
+        if (existingError) {
+            existingError.remove();
+        }
+
+        const errorDiv = document.createElement('div');
+        errorDiv.className = 'form-validation-message error';
+        errorDiv.innerHTML = '<i class="fas fa-exclamation-circle"></i> <span class="form-validation-text"></span>';
+        errorDiv.querySelector('.form-validation-text').textContent = message;
+        input.parentNode.appendChild(errorDiv);
+    },
+
+    clearFieldError(input) {
+        input.classList.remove('invalid');
+
+        const errorMessage = input.parentNode.querySelector('.form-validation-message');
+        if (errorMessage) {
+            errorMessage.remove();
+        }
+    },
+
+    showAlert(message, type = 'error') {
+        const alert = document.getElementById('program-modal-alert');
+        if (alert) {
+            alert.className = `alert alert-${type}`;
+            alert.innerHTML = '<i class="fas fa-exclamation-circle"></i> <span class="alert-msg"></span>';
+            alert.querySelector('.alert-msg').textContent = message;
+            alert.classList.remove('hidden');
+        }
+    },
+
+    hideAlert() {
+        const alert = document.getElementById('program-modal-alert');
+        if (alert) {
+            alert.classList.add('hidden');
+        }
+    },
+
+    handleKeyDown(e) {
+        if (e.key === 'Escape') {
+            this.hideModal();
+        }
+    },
+
+    hideModal() {
+        const modal = document.getElementById('program-modal');
+        if (modal) {
+            modal.remove();
+        }
+
+        if (this._boundHandleKeyDown) {
+            document.removeEventListener('keydown', this._boundHandleKeyDown);
+        }
+
+        this.isEditing = false;
+        this.editingId = null;
+    }
+};
+
+// Make component globally available
+window.ProgramManagement = ProgramManagement;

--- a/frontend/public/templates/admin-dashboard.html
+++ b/frontend/public/templates/admin-dashboard.html
@@ -29,6 +29,7 @@
                 <span class="nav-section-label">Comms</span>
                 <button class="tab-btn nav-link" data-tab="emails"><i class="fas fa-envelope"></i> Email Management</button>
                 <button class="tab-btn nav-link" data-tab="announcements"><i class="fas fa-bullhorn"></i> Announcements</button>
+                <button class="tab-btn nav-link" data-tab="program"><i class="fas fa-calendar-day"></i> Program</button>
             </div>
             <div class="nav-section">
                 <span class="nav-section-label">Finance</span>
@@ -306,6 +307,40 @@
                         <tr>
                             <td colspan="7" class="loading-placeholder">
                                 <i class="fas fa-spinner fa-spin"></i> Loading announcements...
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <!-- Program Tab -->
+    <div class="tab-content" id="program-tab">
+        <div class="data-table">
+            <div class="table-header">
+                <h3 class="table-title">Retreat Program</h3>
+                <div style="display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap;">
+                    <button class="btn btn-sm btn-primary" id="add-program-btn">
+                        <i class="fas fa-plus"></i> Add Program Item
+                    </button>
+                </div>
+            </div>
+            <div class="table-container">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Day</th>
+                            <th>Time</th>
+                            <th>Title</th>
+                            <th>Location</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="program-table-body">
+                        <tr>
+                            <td colspan="5" class="loading-placeholder">
+                                <i class="fas fa-spinner fa-spin"></i> Loading program...
                             </td>
                         </tr>
                     </tbody>

--- a/frontend/public/templates/attendee-dashboard.html
+++ b/frontend/public/templates/attendee-dashboard.html
@@ -163,35 +163,7 @@
                     <h3 class="table-title"><i class="fas fa-calendar-day"></i> Retreat Schedule</h3>
                 </div>
                 <div id="schedule-content" class="table-content" style="padding: 1.5rem; font-size: 0.85rem;">
-                    <div style="margin-bottom: 1rem;">
-                        <div style="font-weight: 600; color: #5eead4; margin-bottom: 0.3rem;">Fri, July 31</div>
-                        <div style="color: var(--text-secondary); line-height: 1.6;">
-                            3:00 PM — Arrival &amp; Registration<br>
-                            5:00 PM — Welcome Session<br>
-                            6:30 PM — Dinner<br>
-                            8:00 PM — Evening Worship
-                        </div>
-                    </div>
-                    <div style="margin-bottom: 1rem;">
-                        <div style="font-weight: 600; color: #5eead4; margin-bottom: 0.3rem;">Sat, August 1</div>
-                        <div style="color: var(--text-secondary); line-height: 1.6;">
-                            8:00 AM — Breakfast<br>
-                            9:30 AM — Morning Session<br>
-                            12:30 PM — Lunch<br>
-                            2:00 PM — Workshops &amp; Activities<br>
-                            5:00 PM — Free Time<br>
-                            6:30 PM — Dinner<br>
-                            8:00 PM — Evening Programme
-                        </div>
-                    </div>
-                    <div>
-                        <div style="font-weight: 600; color: #5eead4; margin-bottom: 0.3rem;">Sun, August 2</div>
-                        <div style="color: var(--text-secondary); line-height: 1.6;">
-                            8:00 AM — Breakfast<br>
-                            9:30 AM — Final Session<br>
-                            12:00 PM — Lunch &amp; Departure
-                        </div>
-                    </div>
+                    <div style="color: var(--text-tertiary);"><i class="fas fa-spinner fa-spin"></i> Loading schedule…</div>
                 </div>
             </div>
 

--- a/functions/_shared/validation.ts
+++ b/functions/_shared/validation.ts
@@ -345,3 +345,24 @@ export const registrationSchema: ValidationSchema = {
     validators: [validators.required, validators.enum(['full', 'installments', 'sponsorship'] as const)]
   }
 };
+
+// Retreat program / schedule items (admin-managed, shown in the attendee portal)
+export const programItemCreateSchema: ValidationSchema = {
+  day_label: { validators: [validators.required, validators.maxLength(100)] },
+  time_label: { validators: [validators.maxLength(50)], optional: true },
+  title: { validators: [validators.required, validators.maxLength(200)] },
+  description: { validators: [validators.maxLength(2000)], optional: true },
+  location: { validators: [validators.maxLength(200)], optional: true },
+  sort_order: { validators: [validators.integer], optional: true }
+};
+
+// Update is a partial: every field optional, so the dynamic UPDATE only writes
+// the fields that were sent.
+export const programItemUpdateSchema: ValidationSchema = {
+  day_label: { validators: [validators.maxLength(100)], optional: true },
+  time_label: { validators: [validators.maxLength(50)], optional: true },
+  title: { validators: [validators.maxLength(200)], optional: true },
+  description: { validators: [validators.maxLength(2000)], optional: true },
+  location: { validators: [validators.maxLength(200)], optional: true },
+  sort_order: { validators: [validators.integer], optional: true }
+};

--- a/functions/api/admin/program/[id].ts
+++ b/functions/api/admin/program/[id].ts
@@ -1,0 +1,123 @@
+// Admin program management — read, update, or delete a single program item.
+
+import type { PagesContext } from '../../../_shared/types.js';
+import { createResponse, checkAdminAuth, handleCORS } from '../../../_shared/auth.js';
+import { validate, programItemUpdateSchema } from '../../../_shared/validation.js';
+import { errors, createErrorResponse, generateRequestId, handleError } from '../../../_shared/errors.js';
+
+interface IdParams {
+  id: string;
+}
+
+export async function onRequestOptions(): Promise<Response> {
+  return handleCORS();
+}
+
+// GET /api/admin/program/:id
+export async function onRequestGet(context: PagesContext<IdParams>): Promise<Response> {
+  const requestId = generateRequestId();
+
+  try {
+    const admin = await checkAdminAuth(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) {
+      return createErrorResponse(errors.unauthorized('Invalid or expired token', requestId));
+    }
+
+    const { results } = await context.env.DB.prepare(
+      'SELECT * FROM program_items WHERE id = ?'
+    ).bind(context.params.id).all();
+
+    if (!results.length) {
+      return createErrorResponse(errors.notFound('Program item', requestId));
+    }
+
+    return createResponse(results[0]);
+  } catch (error) {
+    console.error(`[${requestId}] Error fetching program item:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}
+
+// PUT /api/admin/program/:id - partial update of the provided fields.
+export async function onRequestPut(context: PagesContext<IdParams>): Promise<Response> {
+  const requestId = generateRequestId();
+
+  try {
+    const admin = await checkAdminAuth(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) {
+      return createErrorResponse(errors.unauthorized('Invalid or expired token', requestId));
+    }
+
+    const id = context.params.id;
+    const updateData = await context.request.json() as Record<string, unknown>;
+
+    const validation = validate(updateData, programItemUpdateSchema);
+    if (!validation.valid) {
+      return createErrorResponse(errors.validation(validation.errors, requestId));
+    }
+
+    const { results: existing } = await context.env.DB.prepare(
+      'SELECT id FROM program_items WHERE id = ?'
+    ).bind(id).all();
+    if (!existing.length) {
+      return createErrorResponse(errors.notFound('Program item', requestId));
+    }
+
+    const allowedFields = ['day_label', 'time_label', 'title', 'description', 'location', 'sort_order'];
+    const updateFields: string[] = [];
+    const updateValues: (string | number | null)[] = [];
+
+    for (const [key, value] of Object.entries(updateData)) {
+      if (allowedFields.includes(key) && value !== undefined) {
+        updateFields.push(`${key} = ?`);
+        // Empty strings on optional text fields become NULL; sort_order stays numeric.
+        updateValues.push(value === '' ? null : (value as string | number | null));
+      }
+    }
+
+    if (updateFields.length === 0) {
+      return createErrorResponse(errors.badRequest('No valid fields to update', requestId));
+    }
+
+    updateFields.push('updated_at = CURRENT_TIMESTAMP');
+    updateValues.push(id);
+
+    const result = await context.env.DB.prepare(
+      `UPDATE program_items SET ${updateFields.join(', ')} WHERE id = ?`
+    ).bind(...updateValues).run();
+
+    if (!result.success) {
+      throw new Error('Failed to update program item');
+    }
+
+    return createResponse({ success: true, message: 'Program item updated' });
+  } catch (error) {
+    console.error(`[${requestId}] Error updating program item:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}
+
+// DELETE /api/admin/program/:id
+export async function onRequestDelete(context: PagesContext<IdParams>): Promise<Response> {
+  const requestId = generateRequestId();
+
+  try {
+    const admin = await checkAdminAuth(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) {
+      return createErrorResponse(errors.unauthorized('Invalid or expired token', requestId));
+    }
+
+    const result = await context.env.DB.prepare(
+      'DELETE FROM program_items WHERE id = ?'
+    ).bind(context.params.id).run();
+
+    if (!result.success || result.meta.changes === 0) {
+      return createErrorResponse(errors.notFound('Program item', requestId));
+    }
+
+    return createResponse({ success: true, message: 'Program item deleted' });
+  } catch (error) {
+    console.error(`[${requestId}] Error deleting program item:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}

--- a/functions/api/admin/program/index.ts
+++ b/functions/api/admin/program/index.ts
@@ -1,0 +1,98 @@
+// Admin program management — list all items and create a new one.
+
+import type { PagesContext } from '../../../_shared/types.js';
+import { createResponse, checkAdminAuth, handleCORS } from '../../../_shared/auth.js';
+import { validate, programItemCreateSchema } from '../../../_shared/validation.js';
+import { errors, createErrorResponse, generateRequestId, handleError } from '../../../_shared/errors.js';
+
+export async function onRequestOptions(): Promise<Response> {
+  return handleCORS();
+}
+
+// GET /api/admin/program - list every program item in display order.
+export async function onRequestGet(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+
+  try {
+    const admin = await checkAdminAuth(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) {
+      return createErrorResponse(errors.unauthorized('Invalid or expired token', requestId));
+    }
+
+    const { results } = await context.env.DB.prepare(`
+      SELECT id, day_label, time_label, title, description, location, sort_order, created_at, updated_at
+      FROM program_items
+      ORDER BY sort_order ASC, id ASC
+    `).all();
+
+    return createResponse({ items: results });
+  } catch (error) {
+    console.error(`[${requestId}] Error listing program items:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}
+
+// POST /api/admin/program - create a program item. New items default to the
+// end of the list (max sort_order + 10) unless an explicit sort_order is given.
+export async function onRequestPost(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+
+  try {
+    const admin = await checkAdminAuth(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) {
+      return createErrorResponse(errors.unauthorized('Invalid or expired token', requestId));
+    }
+
+    const body = await context.request.json() as Record<string, unknown>;
+
+    const validation = validate(body, programItemCreateSchema);
+    if (!validation.valid) {
+      return createErrorResponse(errors.validation(validation.errors, requestId));
+    }
+
+    const {
+      day_label,
+      time_label,
+      title,
+      description,
+      location,
+      sort_order,
+    } = body as {
+      day_label: string;
+      time_label?: string;
+      title: string;
+      description?: string;
+      location?: string;
+      sort_order?: number;
+    };
+
+    let order = typeof sort_order === 'number' ? sort_order : null;
+    if (order === null) {
+      const row = await context.env.DB.prepare(
+        'SELECT COALESCE(MAX(sort_order), 0) + 10 AS next FROM program_items'
+      ).first<{ next: number }>();
+      order = row?.next ?? 10;
+    }
+
+    const result = await context.env.DB.prepare(`
+      INSERT INTO program_items (day_label, time_label, title, description, location, sort_order)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).bind(
+      day_label.trim(),
+      time_label?.trim() || null,
+      title.trim(),
+      description?.trim() || null,
+      location?.trim() || null,
+      order,
+    ).run();
+
+    if (!result.success) {
+      throw new Error('Failed to create program item');
+    }
+
+    return createResponse({ id: result.meta.last_row_id, message: 'Program item created' }, 201);
+  } catch (error) {
+    console.error(`[${requestId}] Error creating program item:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}

--- a/functions/api/program.ts
+++ b/functions/api/program.ts
@@ -1,0 +1,38 @@
+// Public retreat program / schedule endpoint.
+//
+// Read-only and unauthenticated: the program is the same generic schedule for
+// everyone, shown in the attendee portal's Schedule view. Admins manage it via
+// /api/admin/program. Items come back as a flat list ordered by sort_order;
+// the client groups them by day_label.
+
+import type { PagesContext } from '../_shared/types.js';
+import { createResponse, handleCORS } from '../_shared/auth.js';
+import { generateRequestId, createErrorResponse, handleError } from '../_shared/errors.js';
+
+export async function onRequestOptions(): Promise<Response> {
+  return handleCORS();
+}
+
+export async function onRequestGet(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+
+  try {
+    const { results } = await context.env.DB.prepare(`
+      SELECT id, day_label, time_label, title, description, location, sort_order
+      FROM program_items
+      ORDER BY sort_order ASC, id ASC
+    `).all();
+
+    return createResponse({ items: results });
+  } catch (error) {
+    // Degrade gracefully if the table isn't migrated yet (025): show an empty
+    // program rather than 500-ing the attendee Schedule view.
+    const msg = error instanceof Error ? error.message : String(error);
+    if (msg.includes('no such table')) {
+      console.warn(`[${requestId}] program_items table missing; returning empty program`);
+      return createResponse({ items: [] });
+    }
+    console.error(`[${requestId}] Error fetching program:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}

--- a/migrations/025_program_items.sql
+++ b/migrations/025_program_items.sql
@@ -1,0 +1,37 @@
+/* Retreat program / schedule, managed by admins and shown in the attendee
+   portal. Replaces the previously hardcoded schedule block in
+   attendee-dashboard.html. Items are grouped by day_label for display and
+   ordered by sort_order (gaps of 10 leave room to insert between items).
+
+   No semicolons anywhere in this comment block. wrangler/D1 splits migrations
+   on the semicolon, so one inside a comment breaks the apply. */
+
+CREATE TABLE IF NOT EXISTS program_items (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  day_label TEXT NOT NULL,
+  time_label TEXT,
+  title TEXT NOT NULL,
+  description TEXT,
+  location TEXT,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_program_items_sort ON program_items(sort_order);
+
+INSERT INTO program_items (day_label, time_label, title, sort_order) VALUES
+  ('Fri, July 31', '3:00 PM', 'Arrival & Registration', 10),
+  ('Fri, July 31', '5:00 PM', 'Welcome Session', 20),
+  ('Fri, July 31', '6:30 PM', 'Dinner', 30),
+  ('Fri, July 31', '8:00 PM', 'Evening Worship', 40),
+  ('Sat, August 1', '8:00 AM', 'Breakfast', 50),
+  ('Sat, August 1', '9:30 AM', 'Morning Session', 60),
+  ('Sat, August 1', '12:30 PM', 'Lunch', 70),
+  ('Sat, August 1', '2:00 PM', 'Workshops & Activities', 80),
+  ('Sat, August 1', '5:00 PM', 'Free Time', 90),
+  ('Sat, August 1', '6:30 PM', 'Dinner', 100),
+  ('Sat, August 1', '8:00 PM', 'Evening Programme', 110),
+  ('Sun, August 2', '8:00 AM', 'Breakfast', 120),
+  ('Sun, August 2', '9:30 AM', 'Final Session', 130),
+  ('Sun, August 2', '12:00 PM', 'Lunch & Departure', 140);


### PR DESCRIPTION
Makes the retreat program (shown in the attendee portal's **Schedule** view) **editable by admins** — create, edit, delete, reorder — instead of being hardcoded in `attendee-dashboard.html`.

## Backend (`17af602`)
- **`migration 025`** — `program_items` table (`day_label`, `time_label`, `title`, `description`, `location`, `sort_order`), **seeded with the existing Fri/Sat/Sun schedule** so the portal is identical on day one.
- **`GET /api/program`** — public read for the attendee Schedule view. Returns an empty program (not a 500) if the table isn't migrated yet.
- **`/api/admin/program` (+ `/[id]`)** — admin list / create / get / update / delete, `checkAdminAuth`-gated, with auto-append ordering (`MAX(sort_order)+10`).
- `programItemCreateSchema` / `programItemUpdateSchema` validation.

## Frontend (`28f2b64`) — mirrors the Announcements pattern
- **Admin**: a new **Program** sidebar tab + table (Day · Time · Title · Location · Actions) and a `program-management.js` modal (day, time, title, description, location, order) for create/edit; delegated edit/delete; wired into the dashboard's parallel data load.
- **Attendee**: the Schedule view fetches `/api/program` and renders it grouped by day (replacing the hardcoded block), lazy-loaded when the view opens. The "Getting There" venue block is unchanged.

## Quality
- All admin/attendee-supplied values are **escaped** on render (`Utils.escapeHtml` / `_escape`); the modal sets values via `.value`/`textContent`. (Deliberate, given this repo's prior stored-XSS findings.)
- `tsc --noEmit` green; all three edited `.js` files pass `node --check`; migration applies cleanly in SQLite (14 items, 3 days). The new **CI** check (typecheck + vitest) will run on this PR.

## ⚠️ Migration must be applied
This is the **first migration to ride the new D1-migrations workflow** (`025`). On merge it should auto-apply **if the production DB has been baselined** (the setup from #26). If the baseline isn't done, the workflow's guard will block it and `025` won't apply — apply it manually then:
```bash
npx wrangler d1 execute attendance_db --remote --file=./migrations/025_program_items.sql
```
Until `025` is applied: the attendee Schedule shows empty (graceful), and the admin Program tab shows a load error (the rest of the dashboard is fine — loads are independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TM9EsRHSBTB4vMRKrRDrRB)_