### PR TITLE
feat(program): drag-and-drop calendar board + mandatory session toggle

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -56,6 +56,9 @@
         </div>
     </div>
 
+    <!-- Vendor: SortableJS powers the drag-and-drop program calendar board -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Sortable/1.15.6/Sortable.min.js" defer></script>
+
     <!-- Core JavaScript Files -->
     <script src="js/utils.js"></script>
     <script src="js/auth.js"></script>

--- a/frontend/public/js/components/admin-dashboard.js
+++ b/frontend/public/js/components/admin-dashboard.js
@@ -417,9 +417,14 @@ const AdminDashboard = {
      * Load program data with loading state
      */
     async loadProgram() {
-        const tableBody = 'program-table-body';
         this.loadingStates.program = true;
-        Utils.showSectionLoading(tableBody, 'Loading program...');
+        const board = document.getElementById('program-board');
+        if (board) {
+            board.innerHTML = `
+                <div style="padding: 2rem; text-align: center; color: var(--text-secondary); width: 100%;">
+                    <i class="fas fa-spinner fa-spin"></i> Loading program...
+                </div>`;
+        }
 
         try {
             const response = await API.get('/admin/program');
@@ -432,9 +437,22 @@ const AdminDashboard = {
             this.data.program = [];
             this.loadingStates.program = false;
             this.failedLoads.add('program');
-            Utils.showSectionError(tableBody, 'Failed to load program', () => {
-                this.loadProgram().then(() => this.updateProgramDisplay());
-            });
+            const b = document.getElementById('program-board');
+            if (b) {
+                b.innerHTML = `
+                    <div style="padding: 2rem; text-align: center; color: var(--error); width: 100%;">
+                        <i class="fas fa-exclamation-triangle"></i> Failed to load program<br>
+                        <button class="btn btn-sm btn-primary" id="program-retry-btn" style="margin-top: 0.75rem;">
+                            <i class="fas fa-redo"></i> Retry
+                        </button>
+                    </div>`;
+                const retry = document.getElementById('program-retry-btn');
+                if (retry) {
+                    retry.addEventListener('click', () => {
+                        this.loadProgram().then(() => this.updateProgramDisplay()).catch(() => {});
+                    });
+                }
+            }
             throw error;
         }
     },
@@ -858,66 +876,231 @@ const AdminDashboard = {
     },
 
     /**
-     * Update program table display
+     * Render the program as a drag-and-drop calendar board: one column per day
+     * (grouped by event_date, chronological), each holding event cards. Cards
+     * can be dragged within a column to reorder or to another column to move to
+     * a different day. SortableJS drives the interaction; persistProgramOrder()
+     * saves the result.
      */
     updateProgramDisplay() {
-        const tbody = document.getElementById('program-table-body');
-        if (!tbody) return;
+        const board = document.getElementById('program-board');
+        if (!board) return;
 
-        if (this.data.program.length === 0) {
-            tbody.innerHTML = `
-                <tr>
-                    <td colspan="7" style="text-align: center; color: var(--text-secondary); padding: 2rem;">
-                        No program items found
-                    </td>
-                </tr>
-            `;
+        this._ensureProgramBoardStyles();
+        this._destroyProgramSortables();
+
+        const program = this.data.program || [];
+        if (program.length === 0) {
+            board.innerHTML = `
+                <div style="padding: 2rem; text-align: center; color: var(--text-secondary); width: 100%;">
+                    No program items yet. Click “Add Program Item” to start building the schedule.
+                </div>`;
             return;
         }
 
-        const dash = '<span style="color: var(--text-tertiary);">-</span>';
+        const dash = '<span style="color: var(--text-tertiary);">—</span>';
 
-        tbody.innerHTML = this.data.program.map(item => {
-            // Prefer the structured date/time; fall back to the legacy labels
-            // for any rows that predate the richer schema (migration 026).
-            const dateText = item.event_date
-                ? Utils.escapeHtml(Utils.program.formatDate(item.event_date))
-                : (item.day_label ? Utils.escapeHtml(item.day_label) : dash);
-            const timeRange = Utils.program.formatTimeRange(item.start_time, item.end_time);
-            const timeText = timeRange
-                ? Utils.escapeHtml(timeRange)
-                : (item.time_label ? Utils.escapeHtml(item.time_label) : dash);
-            const typeIcon = Utils.program.eventTypeIcon(item.event_type);
-            const typeLabel = Utils.escapeHtml(Utils.program.eventTypeLabel(item.event_type));
-            const audienceLabel = Utils.program.audienceLabel(item.audience);
-            const audienceText = audienceLabel ? Utils.escapeHtml(audienceLabel) : dash;
-            // High-priority items get a small flag next to the title; low/normal
-            // stay uncluttered.
-            const priorityTag = item.priority === 'high'
-                ? ' <span class="badge badge-warning" title="High priority"><i class="fas fa-flag"></i> High</span>'
-                : '';
+        // Group by event_date (items already arrive in chronological order).
+        // Any dateless legacy row falls into a trailing "Unscheduled" column.
+        const order = [];
+        const groups = {};
+        program.forEach((item) => {
+            const key = item.event_date || '';
+            if (!(key in groups)) { groups[key] = []; order.push(key); }
+            groups[key].push(item);
+        });
+
+        board.innerHTML = order.map((key) => {
+            const headerLabel = key
+                ? Utils.escapeHtml(Utils.program.formatDate(key))
+                : 'Unscheduled';
+
+            const cards = groups[key].map((item) => {
+                const typeIcon = Utils.program.eventTypeIcon(item.event_type);
+                const typeLabel = Utils.escapeHtml(Utils.program.eventTypeLabel(item.event_type));
+                const range = Utils.program.formatTimeRange(item.start_time, item.end_time);
+                const timeText = range
+                    ? Utils.escapeHtml(range)
+                    : (item.time_label ? Utils.escapeHtml(item.time_label) : dash);
+                const audienceLabel = Utils.program.audienceLabel(item.audience);
+                const audience = (item.audience && item.audience !== 'all' && audienceLabel)
+                    ? `<span class="badge badge-secondary" style="font-size: 0.65rem;">${Utils.escapeHtml(audienceLabel)}</span>`
+                    : '';
+                const mandatory = item.is_mandatory
+                    ? `<span class="badge badge-danger" style="font-size: 0.65rem;" title="Mandatory session"><i class="fas fa-triangle-exclamation"></i> Mandatory</span>`
+                    : '';
+                const priority = item.priority === 'high'
+                    ? `<span class="badge badge-warning" style="font-size: 0.65rem;" title="High priority"><i class="fas fa-flag"></i></span>`
+                    : '';
+                const loc = item.location
+                    ? `<div style="font-size: 0.78rem; color: var(--text-secondary); margin-top: 0.35rem;"><i class="fas fa-location-dot" style="width: 1rem; color: var(--text-tertiary);"></i> ${Utils.escapeHtml(item.location)}</div>`
+                    : '';
+                const contact = item.contact_name
+                    ? `<div style="font-size: 0.75rem; color: var(--text-tertiary); margin-top: 0.2rem;"><i class="fas fa-user" style="width: 1rem;"></i> ${Utils.escapeHtml(item.contact_name)}</div>`
+                    : '';
+
+                return `
+                    <div class="program-card" data-program-id="${item.id}">
+                        <div class="program-card-grip" title="Drag to reorder or move day"><i class="fas fa-grip-vertical"></i></div>
+                        <div class="program-card-body">
+                            <div class="program-card-top">
+                                <span class="program-card-time"><i class="fas ${typeIcon}"></i> ${timeText}</span>
+                                <span class="program-card-flags">${mandatory}${priority}</span>
+                            </div>
+                            <div class="program-card-title">${Utils.escapeHtml(item.title)}</div>
+                            <div class="program-card-meta">
+                                <span class="badge badge-info" style="font-size: 0.65rem;">${typeLabel}</span>
+                                ${audience}
+                            </div>
+                            ${loc}
+                            ${contact}
+                            <div class="program-card-actions">
+                                <button class="btn btn-sm btn-primary edit-program" data-id="${item.id}" title="Edit Program Item">
+                                    <i class="fas fa-edit"></i>
+                                </button>
+                                <button class="btn btn-sm btn-danger delete-program" data-id="${item.id}" title="Delete Program Item">
+                                    <i class="fas fa-trash"></i>
+                                </button>
+                            </div>
+                        </div>
+                    </div>`;
+            }).join('');
 
             return `
-                <tr data-program-id="${item.id}">
-                    <td><strong>${dateText}</strong></td>
-                    <td>${timeText}</td>
-                    <td>${Utils.escapeHtml(item.title)}${priorityTag}</td>
-                    <td><i class="fas ${typeIcon}" style="color: var(--text-tertiary); margin-right: 0.35rem;"></i>${typeLabel}</td>
-                    <td>${audienceText}</td>
-                    <td>${item.location ? Utils.escapeHtml(item.location) : dash}</td>
-                    <td>
-                        <div class="action-buttons">
-                            <button class="btn btn-sm btn-primary edit-program" data-id="${item.id}" title="Edit Program Item">
-                                <i class="fas fa-edit"></i>
-                            </button>
-                            <button class="btn btn-sm btn-danger delete-program" data-id="${item.id}" title="Delete Program Item">
-                                <i class="fas fa-trash"></i>
-                            </button>
-                        </div>
-                    </td>
-                </tr>
-            `;
+                <div class="program-day-col">
+                    <div class="program-day-head">
+                        <span class="program-day-title">${headerLabel}</span>
+                        <span class="program-day-count">${groups[key].length}</span>
+                    </div>
+                    <div class="program-day-cards" data-day-column="${Utils.escapeHtml(key)}">
+                        ${cards}
+                    </div>
+                </div>`;
         }).join('');
+
+        this._initProgramSortables();
+    },
+
+    /**
+     * Turn each day column's card list into a SortableJS instance. All columns
+     * share one group so cards can be dragged between days. If SortableJS isn't
+     * available (e.g. the CDN is blocked), the board still renders as static
+     * cards — only drag-and-drop is disabled.
+     */
+    _initProgramSortables() {
+        if (typeof window.Sortable === 'undefined') {
+            console.warn('SortableJS not loaded; program board drag-and-drop disabled');
+            const hint = document.querySelector('.program-board-hint');
+            if (hint) hint.style.display = 'none';
+            return;
+        }
+        this._programSortables = this._programSortables || [];
+        document.querySelectorAll('#program-board .program-day-cards').forEach((list) => {
+            const instance = window.Sortable.create(list, {
+                group: 'program-board',
+                handle: '.program-card-grip',
+                animation: 150,
+                ghostClass: 'program-card-ghost',
+                chosenClass: 'program-card-chosen',
+                dragClass: 'program-card-drag',
+                onEnd: () => { this.persistProgramOrder(); }
+            });
+            this._programSortables.push(instance);
+        });
+    },
+
+    _destroyProgramSortables() {
+        if (this._programSortables && this._programSortables.length) {
+            this._programSortables.forEach((s) => { try { s.destroy(); } catch (e) { /* already gone */ } });
+        }
+        this._programSortables = [];
+    },
+
+    /**
+     * Read the board's current arrangement and persist it. Each card's column
+     * gives its event_date and its position gives sort_order (gaps of 10). The
+     * whole set is sent to the bulk reorder endpoint in one atomic request. On
+     * success the in-memory data is synced (no re-render needed — the DOM is
+     * already correct); on failure the board is re-rendered to revert the drag.
+     */
+    async persistProgramOrder() {
+        const board = document.getElementById('program-board');
+        if (!board) return;
+
+        const items = [];
+        board.querySelectorAll('.program-day-cards').forEach((list) => {
+            const date = list.getAttribute('data-day-column') || '';
+            const cards = list.querySelectorAll('.program-card');
+            // Keep each column's count badge in sync with what's now inside it.
+            const countEl = list.parentElement
+                ? list.parentElement.querySelector('.program-day-count')
+                : null;
+            if (countEl) countEl.textContent = cards.length;
+            cards.forEach((card, idx) => {
+                const id = Number(card.getAttribute('data-program-id'));
+                if (!id) return;
+                const entry = { id, sort_order: (idx + 1) * 10 };
+                if (date) entry.event_date = date;
+                items.push(entry);
+            });
+        });
+
+        if (items.length === 0) return;
+
+        try {
+            await API.put('/admin/program-reorder', { items });
+            // Sync in-memory state so later edits/renders match the new order.
+            const byId = {};
+            items.forEach((it) => { byId[it.id] = it; });
+            this.data.program.forEach((p) => {
+                const it = byId[p.id];
+                if (it) {
+                    p.sort_order = it.sort_order;
+                    if (it.event_date) p.event_date = it.event_date;
+                }
+            });
+            this.data.program.sort((a, b) =>
+                String(a.event_date || '').localeCompare(String(b.event_date || '')) ||
+                String(a.start_time || '').localeCompare(String(b.start_time || '')) ||
+                ((a.sort_order || 0) - (b.sort_order || 0)) ||
+                ((a.id || 0) - (b.id || 0)));
+        } catch (error) {
+            Utils.showAlert('Failed to save the new order — reverting', 'error');
+            // Re-render from the last known-good in-memory state to undo the drag.
+            this.updateProgramDisplay();
+        }
+    },
+
+    /**
+     * Inject the calendar board styles once (mirrors Utils.initFormStyles).
+     */
+    _ensureProgramBoardStyles() {
+        if (document.getElementById('program-board-styles')) return;
+        const style = document.createElement('style');
+        style.id = 'program-board-styles';
+        style.textContent = `
+            .program-board { display: flex; gap: 1rem; overflow-x: auto; padding: 0.5rem 0.25rem 1rem; align-items: flex-start; }
+            .program-day-col { flex: 0 0 300px; max-width: 300px; background: rgba(255,255,255,0.02); border: 1px solid rgba(255,255,255,0.08); border-radius: 12px; display: flex; flex-direction: column; }
+            .program-day-head { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; padding: 0.85rem 1rem; border-bottom: 1px solid rgba(255,255,255,0.08); }
+            .program-day-title { font-weight: 700; color: #5eead4; font-size: 0.9rem; }
+            .program-day-count { background: rgba(255,255,255,0.08); color: var(--text-secondary); border-radius: 999px; padding: 0.05rem 0.5rem; font-size: 0.72rem; }
+            .program-day-cards { padding: 0.75rem; display: flex; flex-direction: column; gap: 0.6rem; min-height: 60px; flex: 1; }
+            .program-card { display: flex; gap: 0.4rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.09); border-radius: 10px; padding: 0.6rem 0.6rem 0.6rem 0.35rem; }
+            .program-card-grip { cursor: grab; color: var(--text-tertiary); display: flex; align-items: center; padding: 0 0.1rem; }
+            .program-card-grip:active { cursor: grabbing; }
+            .program-card-body { flex: 1; min-width: 0; }
+            .program-card-top { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.4rem; }
+            .program-card-time { font-size: 0.78rem; color: var(--text-secondary); font-weight: 600; }
+            .program-card-flags { display: flex; gap: 0.25rem; flex-wrap: wrap; justify-content: flex-end; }
+            .program-card-title { font-weight: 700; color: #fff; font-size: 0.92rem; margin: 0.25rem 0; word-break: break-word; }
+            .program-card-meta { display: flex; gap: 0.3rem; flex-wrap: wrap; align-items: center; }
+            .program-card-actions { display: flex; gap: 0.35rem; margin-top: 0.6rem; }
+            .program-card-ghost { opacity: 0.4; }
+            .program-card-chosen { box-shadow: 0 0 0 2px var(--primary, #6366f1); }
+            .program-card-drag { transform: rotate(1.5deg); }
+            @media (max-width: 640px) { .program-day-col { flex-basis: 85vw; max-width: 85vw; } }
+        `;
+        document.head.appendChild(style);
     },
 
     /**

--- a/frontend/public/js/components/attendee-dashboard.js
+++ b/frontend/public/js/components/attendee-dashboard.js
@@ -315,6 +315,9 @@ const AttendeeDashboard = {
                     const audience = (item.audience && item.audience !== 'all' && audienceLabel)
                         ? ` <span class="badge badge-secondary" style="font-size: 0.7rem;">${this._escape(audienceLabel)}</span>`
                         : '';
+                    const mandatory = item.is_mandatory
+                        ? ` <span class="badge badge-danger" style="font-size: 0.7rem;"><i class="fas fa-triangle-exclamation"></i> Mandatory</span>`
+                        : '';
                     const contact = item.contact_name
                         ? `<br><span style="color: var(--text-tertiary); font-size: 0.8rem;"><i class="fas fa-user" style="width: 1rem;"></i> ${this._escape(item.contact_name)}</span>`
                         : '';
@@ -323,7 +326,7 @@ const AttendeeDashboard = {
                         : '';
                     return `
                         <div style="margin-bottom: 0.5rem;">
-                            <i class="fas ${icon}" style="width: 1.2rem; color: #5eead4;"></i> ${time}${this._escape(item.title)}${audience}${loc}${contact}${desc}
+                            <i class="fas ${icon}" style="width: 1.2rem; color: #5eead4;"></i> ${time}${this._escape(item.title)}${mandatory}${audience}${loc}${contact}${desc}
                         </div>`;
                 }).join('');
 

--- a/frontend/public/js/components/program-management.js
+++ b/frontend/public/js/components/program-management.js
@@ -24,6 +24,8 @@ const ProgramManagement = {
      * Render modal template
      */
     async renderModal() {
+        this._ensureFormStyles();
+
         const opts = (list) => list
             .map(o => `<option value="${this.escapeHtml(o.value)}">${this.escapeHtml(o.label)}</option>`)
             .join('');
@@ -123,6 +125,18 @@ const ProgramManagement = {
                             </div>
 
                             <div class="form-group">
+                                <label class="form-label">
+                                    <i class="fas fa-triangle-exclamation"></i> Mandatory session
+                                </label>
+                                <label class="program-switch">
+                                    <input type="checkbox" id="program-mandatory" name="is_mandatory">
+                                    <span class="program-switch-slider"></span>
+                                    <span class="program-switch-text">Attendance required</span>
+                                </label>
+                                <small class="form-help">Mandatory sessions are highlighted on the attendee schedule.</small>
+                            </div>
+
+                            <div class="form-group">
                                 <label for="program-description" class="form-label">
                                     <i class="fas fa-edit"></i> Description (Optional)
                                 </label>
@@ -181,6 +195,7 @@ const ProgramManagement = {
             document.getElementById('program-priority').value = editData.priority || 'normal';
             document.getElementById('program-location').value = editData.location || '';
             document.getElementById('program-contact').value = editData.contact_name || '';
+            document.getElementById('program-mandatory').checked = !!editData.is_mandatory;
             document.getElementById('program-description').value = editData.description || '';
             document.getElementById('program-order').value =
                 editData.sort_order != null ? editData.sort_order : '';
@@ -250,6 +265,10 @@ const ProgramManagement = {
             data.sort_order = parseInt(data.sort_order, 10);
         }
 
+        // Checkboxes only appear in FormData when checked; read the element
+        // directly so the flag is always sent as 0/1 (so unchecking persists).
+        data.is_mandatory = document.getElementById('program-mandatory').checked ? 1 : 0;
+
         const submitBtn = document.getElementById('save-program');
 
         try {
@@ -310,6 +329,27 @@ const ProgramManagement = {
     /**
      * Utility methods
      */
+    /**
+     * Inject the mandatory-toggle switch styles once (the modal is rebuilt on
+     * every open, but the stylesheet only needs to exist once).
+     */
+    _ensureFormStyles() {
+        if (document.getElementById('program-form-styles')) return;
+        const style = document.createElement('style');
+        style.id = 'program-form-styles';
+        style.textContent = `
+            .program-switch { display: inline-flex; align-items: center; gap: 0.6rem; cursor: pointer; user-select: none; }
+            .program-switch input { position: absolute; opacity: 0; width: 0; height: 0; }
+            .program-switch-slider { position: relative; width: 42px; height: 24px; background: rgba(255,255,255,0.2); border-radius: 999px; transition: background 0.2s; flex: 0 0 auto; }
+            .program-switch-slider::before { content: ''; position: absolute; top: 3px; left: 3px; width: 18px; height: 18px; background: #fff; border-radius: 50%; transition: transform 0.2s; }
+            .program-switch input:checked + .program-switch-slider { background: var(--primary, #6366f1); }
+            .program-switch input:checked + .program-switch-slider::before { transform: translateX(18px); }
+            .program-switch input:focus-visible + .program-switch-slider { box-shadow: 0 0 0 3px rgba(99,102,241,0.4); }
+            .program-switch-text { font-size: 0.85rem; color: var(--text-secondary); }
+        `;
+        document.head.appendChild(style);
+    },
+
     escapeHtml(value) {
         return String(value ?? '')
             .replace(/&/g, '&amp;')

--- a/frontend/public/templates/admin-dashboard.html
+++ b/frontend/public/templates/admin-dashboard.html
@@ -321,32 +321,18 @@
             <div class="table-header">
                 <h3 class="table-title">Retreat Program</h3>
                 <div style="display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap;">
+                    <span class="program-board-hint" style="color: var(--text-tertiary); font-size: 0.8rem;">
+                        <i class="fas fa-arrows-up-down-left-right"></i> Drag cards to reorder or move between days
+                    </span>
                     <button class="btn btn-sm btn-primary" id="add-program-btn">
                         <i class="fas fa-plus"></i> Add Program Item
                     </button>
                 </div>
             </div>
-            <div class="table-container">
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th>Date</th>
-                            <th>Time</th>
-                            <th>Title</th>
-                            <th>Type</th>
-                            <th>Audience</th>
-                            <th>Location</th>
-                            <th>Actions</th>
-                        </tr>
-                    </thead>
-                    <tbody id="program-table-body">
-                        <tr>
-                            <td colspan="7" class="loading-placeholder">
-                                <i class="fas fa-spinner fa-spin"></i> Loading program...
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+            <div id="program-board" class="program-board">
+                <div class="program-board-loading" style="padding: 2rem; text-align: center; color: var(--text-secondary);">
+                    <i class="fas fa-spinner fa-spin"></i> Loading program...
+                </div>
             </div>
         </div>
     </div>

--- a/functions/_shared/validation.ts
+++ b/functions/_shared/validation.ts
@@ -363,6 +363,7 @@ export const programItemCreateSchema: ValidationSchema = {
   event_type: { validators: [validators.enum(PROGRAM_EVENT_TYPES)], optional: true },
   audience: { validators: [validators.enum(PROGRAM_AUDIENCES)], optional: true },
   priority: { validators: [validators.enum(PROGRAM_PRIORITIES)], optional: true },
+  is_mandatory: { validators: [validators.integer], optional: true },
   // Legacy free-text fields, still accepted for backward compatibility.
   day_label: { validators: [validators.maxLength(100)], optional: true },
   time_label: { validators: [validators.maxLength(50)], optional: true },
@@ -382,6 +383,7 @@ export const programItemUpdateSchema: ValidationSchema = {
   event_type: { validators: [validators.enum(PROGRAM_EVENT_TYPES)], optional: true },
   audience: { validators: [validators.enum(PROGRAM_AUDIENCES)], optional: true },
   priority: { validators: [validators.enum(PROGRAM_PRIORITIES)], optional: true },
+  is_mandatory: { validators: [validators.integer], optional: true },
   day_label: { validators: [validators.maxLength(100)], optional: true },
   time_label: { validators: [validators.maxLength(50)], optional: true },
   sort_order: { validators: [validators.integer], optional: true }

--- a/functions/api/admin/program-reorder.ts
+++ b/functions/api/admin/program-reorder.ts
@@ -1,0 +1,100 @@
+// Admin program management — bulk reorder / re-day program items.
+//
+// Backs the drag-and-drop calendar board: when an admin drops a card, the
+// client sends the full desired state for the affected cards as
+// { items: [{ id, event_date, sort_order }, ...] }. Each entry's event_date
+// (the column it now lives in) and sort_order (its position in that column)
+// are written in a single atomic D1 batch so a half-applied reorder can never
+// be observed.
+//
+// Lives at /api/admin/program-reorder (a sibling of the program/ directory)
+// rather than program/reorder so it can never be shadowed by the program/[id]
+// dynamic route.
+
+import type { PagesContext } from '../../_shared/types.js';
+import { createResponse, checkAdminAuth, handleCORS } from '../../_shared/auth.js';
+import { errors, createErrorResponse, generateRequestId, handleError } from '../../_shared/errors.js';
+
+interface ReorderItem {
+  id: number;
+  sort_order: number;
+  event_date?: string;
+}
+
+const MAX_ITEMS = 1000;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export async function onRequestOptions(): Promise<Response> {
+  return handleCORS();
+}
+
+// PUT /api/admin/program-reorder
+export async function onRequestPut(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+
+  try {
+    const admin = await checkAdminAuth(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) {
+      return createErrorResponse(errors.unauthorized('Invalid or expired token', requestId));
+    }
+
+    const body = await context.request.json() as { items?: unknown };
+    const rawItems = body?.items;
+
+    if (!Array.isArray(rawItems) || rawItems.length === 0) {
+      return createErrorResponse(errors.badRequest('items must be a non-empty array', requestId));
+    }
+    if (rawItems.length > MAX_ITEMS) {
+      return createErrorResponse(errors.badRequest(`Cannot reorder more than ${MAX_ITEMS} items at once`, requestId));
+    }
+
+    // Validate every entry up front; reject the whole request on the first bad
+    // one so we never apply a partial, half-validated reorder.
+    const items: ReorderItem[] = [];
+    for (const raw of rawItems) {
+      const entry = raw as Record<string, unknown>;
+      const id = Number(entry.id);
+      const sortOrder = Number(entry.sort_order);
+
+      if (!Number.isInteger(id) || id <= 0) {
+        return createErrorResponse(errors.badRequest('Each item needs a positive integer id', requestId));
+      }
+      if (!Number.isInteger(sortOrder)) {
+        return createErrorResponse(errors.badRequest('Each item needs an integer sort_order', requestId));
+      }
+
+      const item: ReorderItem = { id, sort_order: sortOrder };
+
+      if (entry.event_date !== undefined && entry.event_date !== null && entry.event_date !== '') {
+        const date = String(entry.event_date);
+        if (!DATE_RE.test(date)) {
+          return createErrorResponse(errors.badRequest('event_date must be YYYY-MM-DD', requestId));
+        }
+        item.event_date = date;
+      }
+
+      items.push(item);
+    }
+
+    // One prepared statement per item; D1 runs them as a single atomic batch.
+    const withDate = context.env.DB.prepare(
+      'UPDATE program_items SET event_date = ?, sort_order = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?'
+    );
+    const withoutDate = context.env.DB.prepare(
+      'UPDATE program_items SET sort_order = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?'
+    );
+
+    const statements = items.map((item) =>
+      item.event_date !== undefined
+        ? withDate.bind(item.event_date, item.sort_order, item.id)
+        : withoutDate.bind(item.sort_order, item.id)
+    );
+
+    await context.env.DB.batch(statements);
+
+    return createResponse({ success: true, updated: items.length });
+  } catch (error) {
+    console.error(`[${requestId}] Error reordering program items:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}

--- a/functions/api/admin/program/[id].ts
+++ b/functions/api/admin/program/[id].ts
@@ -65,17 +65,22 @@ export async function onRequestPut(context: PagesContext<IdParams>): Promise<Res
 
     const allowedFields = [
       'event_date', 'start_time', 'end_time', 'title', 'description', 'location',
-      'contact_name', 'event_type', 'audience', 'priority',
+      'contact_name', 'event_type', 'audience', 'priority', 'is_mandatory',
       'day_label', 'time_label', 'sort_order',
     ];
     // event_type/audience/priority are NOT NULL — never write null to them.
     const notNullFields = new Set(['event_type', 'audience', 'priority']);
+    // is_mandatory is a NOT NULL 0/1 flag; coerce anything truthy to 1.
+    const boolFields = new Set(['is_mandatory']);
     const updateFields: string[] = [];
     const updateValues: (string | number | null)[] = [];
 
     for (const [key, value] of Object.entries(updateData)) {
       if (allowedFields.includes(key) && value !== undefined) {
-        if (notNullFields.has(key)) {
+        if (boolFields.has(key)) {
+          updateFields.push(`${key} = ?`);
+          updateValues.push(value ? 1 : 0);
+        } else if (notNullFields.has(key)) {
           if (value === '' || value === null) continue; // skip rather than null out
           updateFields.push(`${key} = ?`);
           updateValues.push(value as string);

--- a/functions/api/admin/program/index.ts
+++ b/functions/api/admin/program/index.ts
@@ -22,7 +22,7 @@ export async function onRequestGet(context: PagesContext): Promise<Response> {
     const { results } = await context.env.DB.prepare(`
       SELECT id, event_date, start_time, end_time, day_label, time_label,
              title, description, location, contact_name, event_type, audience,
-             priority, sort_order, created_at, updated_at
+             priority, is_mandatory, sort_order, created_at, updated_at
       FROM program_items
       ORDER BY event_date ASC, start_time ASC, sort_order ASC, id ASC
     `).all();
@@ -63,6 +63,7 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
       event_type,
       audience,
       priority,
+      is_mandatory,
       sort_order,
     } = body as {
       event_date: string;
@@ -75,6 +76,7 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
       event_type?: string;
       audience?: string;
       priority?: string;
+      is_mandatory?: number | boolean;
       sort_order?: number;
     };
 
@@ -89,8 +91,8 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
     const result = await context.env.DB.prepare(`
       INSERT INTO program_items (
         event_date, start_time, end_time, title, description, location,
-        contact_name, event_type, audience, priority, sort_order
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        contact_name, event_type, audience, priority, is_mandatory, sort_order
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).bind(
       event_date.trim(),
       start_time?.trim() || null,
@@ -103,6 +105,8 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
       event_type || 'general',
       audience || 'all',
       priority || 'normal',
+      // is_mandatory is NOT NULL (0/1); coerce anything truthy to 1.
+      is_mandatory ? 1 : 0,
       order,
     ).run();
 

--- a/functions/api/program.ts
+++ b/functions/api/program.ts
@@ -20,7 +20,7 @@ export async function onRequestGet(context: PagesContext): Promise<Response> {
     const { results } = await context.env.DB.prepare(`
       SELECT id, event_date, start_time, end_time, day_label, time_label,
              title, description, location, contact_name, event_type, audience,
-             priority, sort_order
+             priority, is_mandatory, sort_order
       FROM program_items
       ORDER BY event_date ASC, start_time ASC, sort_order ASC, id ASC
     `).all();

--- a/migrations/027_program_mandatory.sql
+++ b/migrations/027_program_mandatory.sql
@@ -1,0 +1,11 @@
+/* Mandatory-attendance flag for program items. Sessions flagged mandatory are
+   highlighted on the admin board and the attendee schedule so everyone knows
+   which parts of the retreat are required rather than optional.
+
+   Stored as an integer 0/1 (SQLite has no native boolean). NOT NULL with a
+   default of 0 so every existing row is "optional" until an admin marks it.
+
+   No semicolons anywhere in this comment block. wrangler/D1 splits migrations
+   on the semicolon, so one inside a comment breaks the apply. */
+
+ALTER TABLE program_items ADD COLUMN is_mandatory INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
Follow-up to #33 (richer program fields, already merged). Turns the admin program table into a drag-and-drop calendar board and adds a per-session **mandatory** flag.

> ⚠️ This is the work that did **not** make it into #33 — including **migration 027** and the board UI. #33 merged at its first commit; this commit was pushed afterward, so it was rebased onto `main` and opened as a new PR.

## Calendar board (admin)
- One column per day (grouped by `event_date`, chronological), each holding event cards with the type icon, time range, audience, location, contact and priority/mandatory flags.
- **Drag a card within a day to reorder, or to another day's column to change its date.** A grip handle starts the drag so clicking Edit/Delete never triggers one.
- Each drop persists the whole arrangement in **one atomic request** to a new `/api/admin/program-reorder` endpoint (D1 `batch()`), placed as a sibling of `program/` so it can never be shadowed by the `program/[id]` dynamic route.
- **Graceful degradation**: if SortableJS can't load, the board still renders as static cards and edit/delete keep working.

## Mandatory toggle
- New `is_mandatory` flag (**`migrations/027_program_mandatory.sql`**, `NOT NULL DEFAULT 0`) with a switch in the add/edit form.
- Shown as a red **"Mandatory"** badge on the admin cards and the attendee schedule.
- Added to validation, create, update and both read endpoints; coerced to 0/1, never written NULL.

## Verification
- `tsc --noEmit` clean · 57/57 vitest tests pass
- Migrations 025 → 026 → 027 apply cleanly in SQLite; reorder SQL verified against seed data
- **Browser smoke test (headless Chromium): 11/11 checks** — real SortableJS drag of a card across day columns fired the reorder PUT with the correct payload (moved card's `event_date` updated, target column re-sequenced to 10/20/30), and the DOM reflected the move.

## Deploy note
⚠️ **Migration 027 must be applied to production** (`wrangler d1 migrations apply <db> --remote`, or the d1-migrations workflow on merge) before the mandatory flag persists. Migration 026 should already be applied via #33's merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TM9EsRHSBTB4vMRKrRDrRB)_