### PR TITLE
fix(program): creating a program item fails with "Required field is missing"

### DIFF
--- a/functions/api/admin/program/index.ts
+++ b/functions/api/admin/program/index.ts
@@ -64,6 +64,8 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
       audience,
       priority,
       is_mandatory,
+      day_label,
+      time_label,
       sort_order,
     } = body as {
       event_date: string;
@@ -77,6 +79,8 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
       audience?: string;
       priority?: string;
       is_mandatory?: number | boolean;
+      day_label?: string;
+      time_label?: string;
       sort_order?: number;
     };
 
@@ -88,11 +92,19 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
       order = row?.next ?? 10;
     }
 
+    // day_label is a legacy NOT NULL column (migration 025) that SQLite won't
+    // let us drop. event_date is the canonical "day" now, so derive day_label
+    // from it when the caller doesn't send one — otherwise the INSERT fails a
+    // NOT NULL constraint. time_label is nullable; mirror start_time similarly.
+    const dayLabelValue = (day_label?.trim()) || event_date.trim();
+    const timeLabelValue = (time_label?.trim()) || start_time?.trim() || null;
+
     const result = await context.env.DB.prepare(`
       INSERT INTO program_items (
         event_date, start_time, end_time, title, description, location,
-        contact_name, event_type, audience, priority, is_mandatory, sort_order
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        contact_name, event_type, audience, priority, is_mandatory,
+        day_label, time_label, sort_order
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).bind(
       event_date.trim(),
       start_time?.trim() || null,
@@ -107,6 +119,9 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
       priority || 'normal',
       // is_mandatory is NOT NULL (0/1); coerce anything truthy to 1.
       is_mandatory ? 1 : 0,
+      // day_label is NOT NULL (legacy); time_label is nullable.
+      dayLabelValue,
+      timeLabelValue,
       order,
     ).run();
 


### PR DESCRIPTION
## The bug
Every "Add Program Item" submission returns **400 "Required field is missing"**, even with all fields filled.

## Root cause
It's not validation — validation passes. It's the **INSERT**:
- Migration `025` created `program_items.day_label` as `NOT NULL`, and SQLite can't drop that constraint.
- The richer-fields create endpoint (#33) switched to `event_date` and **stopped inserting `day_label`**.
- So every insert hits `NOT NULL constraint failed: program_items.day_label`, which `handleError` maps to the generic `"Required field is missing"` 400 (errors.ts:179, the `NOT NULL` → badRequest branch).

This slipped through because the migration tests only checked that migrations *apply* and that `SELECT` works — they never ran an `INSERT` through the endpoint against the migrated schema.

## The fix
Keep populating the legacy `day_label` / `time_label` columns on insert, deriving them from `event_date` / `start_time` when the caller doesn't supply them. No table-recreation migration needed — it works against the existing production schema immediately.

```js
const dayLabelValue  = (day_label?.trim())  || event_date.trim();
const timeLabelValue = (time_label?.trim()) || start_time?.trim() || null;
```

## Verification
Reproduced against the **real migrated schema** (`025`+`026`+`027`):
- **Old** INSERT → `NOT NULL constraint failed: program_items.day_label` (exactly what users hit)
- **New** INSERT → succeeds, row created
- `tsc --noEmit` clean · 57/57 vitest tests pass

## Note
Update (`[id].ts`) and reorder (`program-reorder.ts`) were unaffected — only create omitted the legacy column. A future cleanup could recreate the table to drop the `NOT NULL` on `day_label`, but that's not needed for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TM9EsRHSBTB4vMRKrRDrRB)_