### PR TITLE
feat(registrations): admin button to open/close public registration

### DIFF
--- a/frontend/public/js/components/admin-dashboard.js
+++ b/frontend/public/js/components/admin-dashboard.js
@@ -543,6 +543,7 @@ const AdminDashboard = {
         this.updateStatsDisplay();
         this.updateAttendeesDisplay();
         this.updateRegistrationsDisplay();
+        this.loadRegistrationStatus();
         this.updateAnnouncementsDisplay();
         this.updateProgramDisplay();
         this.updateRoomsDisplay();
@@ -1894,6 +1895,11 @@ const AdminDashboard = {
             addProgramBtn.addEventListener('click', () => this.showAddProgramModal());
         }
 
+        const toggleRegBtn = document.getElementById('toggle-registrations-btn');
+        if (toggleRegBtn) {
+            toggleRegBtn.addEventListener('click', () => this.toggleRegistrations());
+        }
+
         // Add room button
         const addRoomBtn = document.getElementById('add-room-btn');
         if (addRoomBtn) {
@@ -2161,6 +2167,60 @@ const AdminDashboard = {
             await window.ProgramManagement.showModal(null);
         } else {
             Utils.showAlert('Program management component not loaded', 'error');
+        }
+    },
+
+    /**
+     * Load + render the public-registration open/closed control shown in the
+     * Registrations tab header.
+     */
+    async loadRegistrationStatus() {
+        try {
+            const res = await API.get('/admin/settings/registration');
+            this._renderRegistrationToggle(!!res.open);
+        } catch (e) {
+            // Leave the control hidden if we can't read the setting.
+            console.warn('Failed to load registration status:', e);
+        }
+    },
+
+    _renderRegistrationToggle(open) {
+        this._registrationsOpen = open;
+        const badge = document.getElementById('registrations-status');
+        const btn = document.getElementById('toggle-registrations-btn');
+        if (!badge || !btn) return;
+        badge.style.display = '';
+        btn.style.display = '';
+        if (open) {
+            badge.className = 'badge badge-success';
+            badge.innerHTML = '<i class="fas fa-circle-check"></i> Registration open';
+            btn.className = 'btn btn-sm btn-danger';
+            btn.innerHTML = '<i class="fas fa-lock"></i> Close Registrations';
+        } else {
+            badge.className = 'badge badge-secondary';
+            badge.innerHTML = '<i class="fas fa-ban"></i> Registration closed';
+            btn.className = 'btn btn-sm btn-success';
+            btn.innerHTML = '<i class="fas fa-lock-open"></i> Open Registrations';
+        }
+    },
+
+    async toggleRegistrations() {
+        const next = !this._registrationsOpen;
+        const msg = next
+            ? 'Re-open public registration? Families will be able to submit new registrations again.'
+            : 'Close public registration? New families will not be able to submit registrations until you re-open it.';
+        if (!confirm(msg)) return;
+
+        const btn = document.getElementById('toggle-registrations-btn');
+        if (btn) btn.disabled = true;
+        try {
+            await API.put('/admin/settings/registration', { open: next });
+            this._renderRegistrationToggle(next);
+            Utils.showAlert(next ? 'Registration re-opened' : 'Registration closed', 'success');
+        } catch (e) {
+            Utils.showAlert('Failed to update registration status: ' + e.message, 'error');
+        } finally {
+            if (btn) btn.disabled = false;
         }
     },
 

--- a/frontend/public/register.html
+++ b/frontend/public/register.html
@@ -995,7 +995,30 @@
         }
 
         // Initialize
-        document.addEventListener('DOMContentLoaded', () => {
+        document.addEventListener('DOMContentLoaded', async () => {
+            // If an admin has closed registration, replace the form with a
+            // notice and skip wiring the (now-absent) form controls.
+            try {
+                const statusResp = await fetch('/api/register');
+                if (statusResp.ok) {
+                    const info = await statusResp.json();
+                    if (info && info.registrationsOpen === false) {
+                        const wrap = document.getElementById('registration-form');
+                        if (wrap) {
+                            wrap.innerHTML = `
+                                <div class="info-box" style="text-align: center; padding: 2.5rem 1.5rem;">
+                                    <h2 style="margin-top: 0;"><i class="fas fa-lock"></i> Registration is closed</h2>
+                                    <p style="margin-bottom: 0;">Registration for the retreat is currently closed. Please check back later, or contact the organisers if you have any questions.</p>
+                                </div>`;
+                        }
+                        return;
+                    }
+                }
+            } catch (e) {
+                // If the status check fails, fall through — the POST endpoint
+                // still enforces the closure server-side.
+            }
+
             // Add member button
             document.getElementById('add-member-btn').addEventListener('click', addMember);
 

--- a/frontend/public/templates/admin-dashboard.html
+++ b/frontend/public/templates/admin-dashboard.html
@@ -241,6 +241,8 @@
             <div class="table-header">
                 <h3 class="table-title">Pending Registrations</h3>
                 <div style="display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap;">
+                    <span id="registrations-status" class="badge" style="display: none;"></span>
+                    <button class="btn btn-sm" id="toggle-registrations-btn" style="display: none;"></button>
                     <select class="search-box" id="filter-registrations-status" style="width: auto;">
                         <option value="">All Status</option>
                         <option value="pending" selected>Pending</option>

--- a/functions/_shared/settings.ts
+++ b/functions/_shared/settings.ts
@@ -2,6 +2,7 @@
 
 const CHECK_IN_OPEN_KEY = 'check_in_opens_at';
 const CHECK_IN_CLOSE_KEY = 'check_in_closes_at';
+const REGISTRATIONS_OPEN_KEY = 'registrations_open';
 
 export interface CheckInWindow {
   opens_at: string | null;
@@ -24,6 +25,21 @@ export async function setSetting(db: D1Database, key: string, value: string | nu
     `INSERT INTO settings (key, value, updated_at, updated_by) VALUES (?, ?, CURRENT_TIMESTAMP, ?)
      ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = CURRENT_TIMESTAMP, updated_by = excluded.updated_by`
   ).bind(key, value, adminUser).run();
+}
+
+/**
+ * Whether the public registration form is accepting new submissions.
+ * Defaults to OPEN when the setting has never been written, so existing
+ * deployments keep accepting sign-ups until an admin explicitly closes it.
+ */
+export async function getRegistrationsOpen(db: D1Database): Promise<boolean> {
+  const v = await getSetting(db, REGISTRATIONS_OPEN_KEY);
+  if (v === null) return true;
+  return v === '1' || v === 'true';
+}
+
+export async function setRegistrationsOpen(db: D1Database, open: boolean, adminUser: string): Promise<void> {
+  await setSetting(db, REGISTRATIONS_OPEN_KEY, open ? '1' : '0', adminUser);
 }
 
 export async function getCheckInWindow(db: D1Database): Promise<CheckInWindow> {

--- a/functions/api/admin/settings/registration.ts
+++ b/functions/api/admin/settings/registration.ts
@@ -1,0 +1,55 @@
+// GET/PUT /api/admin/settings/registration
+// Reads or flips whether the public registration form is accepting new
+// submissions. Body for PUT: { open: boolean }.
+
+import type { PagesContext } from '../../../_shared/types.js';
+import { createResponse, checkAdminAuth, handleCORS } from '../../../_shared/auth.js';
+import { errors, createErrorResponse, generateRequestId, handleError } from '../../../_shared/errors.js';
+import { getRegistrationsOpen, setRegistrationsOpen } from '../../../_shared/settings.js';
+
+export async function onRequestOptions(): Promise<Response> {
+  return handleCORS();
+}
+
+export async function onRequestGet(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+  try {
+    const admin = await checkAdminAuth(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) return createErrorResponse(errors.unauthorized('Invalid or expired token', requestId));
+
+    const open = await getRegistrationsOpen(context.env.DB);
+    return createResponse({ open });
+  } catch (error) {
+    console.error(`[${requestId}] registration setting GET error:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}
+
+export async function onRequestPut(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+  try {
+    const admin = await checkAdminAuth(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) return createErrorResponse(errors.unauthorized('Invalid or expired token', requestId));
+
+    const body = await context.request.json() as { open?: unknown };
+    if (typeof body.open !== 'boolean') {
+      return createErrorResponse(errors.badRequest('open must be a boolean', requestId));
+    }
+
+    await setRegistrationsOpen(context.env.DB, body.open, admin.user);
+
+    try {
+      await context.env.DB.prepare(
+        `INSERT INTO audit_log (admin_user, action, entity_type, entity_id, details)
+         VALUES (?, 'set_registrations_open', 'settings', 0, ?)`
+      ).bind(admin.user, JSON.stringify({ open: body.open })).run();
+    } catch (err) {
+      console.warn(`[${requestId}] audit_log write failed`, err);
+    }
+
+    return createResponse({ open: body.open });
+  } catch (error) {
+    console.error(`[${requestId}] registration setting PUT error:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}

--- a/functions/api/register.ts
+++ b/functions/api/register.ts
@@ -6,6 +6,7 @@ import { createResponse, handleCORS } from '../_shared/auth.js';
 import { errors, createErrorResponse, generateRequestId, handleError } from '../_shared/errors.js';
 import { escapeHtml } from '../_shared/sanitize.js';
 import { sendEmailOrThrow, isEmailReady } from '../_shared/email.js';
+import { getRegistrationsOpen } from '../_shared/settings.js';
 
 // Pricing constants
 const PRICING = {
@@ -44,13 +45,14 @@ export async function onRequestOptions(): Promise<Response> {
   return handleCORS();
 }
 
-// GET /api/register - Get registration form info (pricing, etc.)
-export async function onRequestGet(_context: PagesContext): Promise<Response> {
+// GET /api/register - Get registration form info (pricing, status, etc.)
+export async function onRequestGet(context: PagesContext): Promise<Response> {
   const requestId = generateRequestId();
 
   try {
     // Return public info about registration options
     const roomTypes = ['family', 'single', 'double', 'suite', 'standard'];
+    const registrationsOpen = await getRegistrationsOpen(context.env.DB);
 
     return createResponse({
       roomTypes,
@@ -59,7 +61,10 @@ export async function onRequestGet(_context: PagesContext): Promise<Response> {
         child: { price: PRICING.child, description: 'Children (6-16 years)' },
         infant: { price: PRICING.infant, description: 'Under 6 years (FREE)' }
       },
-      message: 'Registration is open. Please fill out the form to register your family.'
+      registrationsOpen,
+      message: registrationsOpen
+        ? 'Registration is open. Please fill out the form to register your family.'
+        : 'Registration is currently closed.'
     });
   } catch (error) {
     console.error(`[${requestId}] Error fetching registration info:`, error);
@@ -105,6 +110,11 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
   const requestId = generateRequestId();
 
   try {
+    // Hard stop if an admin has closed registration.
+    if (!await getRegistrationsOpen(context.env.DB)) {
+      return createErrorResponse(errors.forbidden('Registration is currently closed.', requestId));
+    }
+
     const clientIP = context.request.headers.get('CF-Connecting-IP') ||
                      context.request.headers.get('X-Forwarded-For') ||
                      'unknown';


### PR DESCRIPTION
Adds a **Close Registrations / Open Registrations** toggle to the admin Registrations tab so organisers can stop accepting new sign-ups.

## What it does
- **Admin header** (Registrations tab) gains a status badge + toggle button: green **"Registration open" → red "Close Registrations"**, and when closed, grey **"Registration closed" → green "Open Registrations"**. Toggling asks for confirmation.
- **Public registration is blocked when closed** at two levels:
  - Server: `POST /api/register` returns **403** with "Registration is currently closed." (the authoritative gate).
  - Page: `register.html` checks status on load and shows a **"Registration is closed"** notice instead of the form.

## How it's built
- New **`registrations_open`** setting in the existing generic `settings` k/v table. **Defaults to OPEN** when unset, so current behaviour is unchanged until an admin closes it. **No migration needed** (the `settings` table already exists).
- `_shared/settings.ts`: `getRegistrationsOpen` / `setRegistrationsOpen` helpers (mirrors the check-in-window pattern).
- New **`GET`/`PUT /api/admin/settings/registration`** (admin-auth) to read/flip the flag, with an `audit_log` entry on change.
- `GET /api/register` now returns `registrationsOpen` + an appropriate message.

## Verification
- `tsc --noEmit` clean · 57/57 vitest tests pass.
- **Headless-browser smoke (6/6):** drives the admin toggle (open → `PUT {open:false}` → button flips to "Open Registrations") and confirms the public page replaces the form with the closed notice. Screenshots of both admin states + the public closed page shared in the chat.

No schema or migration changes — frontend + Functions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TM9EsRHSBTB4vMRKrRDrRB)_