### PR TITLE
Case-insensitive attendee login + remove login hero side-shading

### DIFF
--- a/frontend/public/css/components.css
+++ b/frontend/public/css/components.css
@@ -1639,7 +1639,6 @@ select.form-input option,
   padding: var(--space-3) var(--space-4);
   background: rgba(255, 255, 255, 0.09);
   border-radius: var(--radius-lg);
-  border-left: 3px solid rgba(255, 255, 255, 0.5);
 }
 
 .brand-scripture i { margin-right: var(--space-2); opacity: 0.85; }

--- a/functions/api/change-password.ts
+++ b/functions/api/change-password.ts
@@ -31,6 +31,9 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
   try {
     const body = await context.request.json() as Record<string, unknown>;
     const ref = typeof body.ref === 'string' ? body.ref.trim() : '';
+    // Reference number is case-insensitive (matches login); upper-case for
+    // rate-limit bucketing, and match the row with COLLATE NOCASE below.
+    const refKey = ref.toUpperCase();
     const currentPassword = typeof body.current_password === 'string' ? body.current_password : '';
     const newPassword = typeof body.new_password === 'string' ? body.new_password : '';
 
@@ -49,23 +52,23 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
                      'unknown';
 
     // Reuse the login rate limiter — same brute-force surface.
-    const rateLimit = await checkRateLimit(context.env.DB, ref, 'attendee', clientIP);
+    const rateLimit = await checkRateLimit(context.env.DB, refKey, 'attendee', clientIP);
     if (!rateLimit.allowed) {
       return createErrorResponse(errors.rateLimited(Math.ceil((rateLimit.resetTime - Date.now()) / 1000), requestId));
     }
 
     const { results } = await context.env.DB.prepare(
-      'SELECT id, password_hash FROM attendees WHERE ref_number = ?'
+      'SELECT id, password_hash FROM attendees WHERE ref_number = ? COLLATE NOCASE'
     ).bind(ref).all();
     if (!results.length) {
-      await recordLoginAttempt(context.env.DB, ref, 'attendee', false, clientIP);
+      await recordLoginAttempt(context.env.DB, refKey, 'attendee', false, clientIP);
       return createErrorResponse(errors.unauthorized('Invalid credentials', requestId));
     }
     const attendee = results[0] as unknown as AttendeeRow;
 
     const ok = await verifyPassword(currentPassword, attendee.password_hash);
     if (!ok) {
-      await recordLoginAttempt(context.env.DB, ref, 'attendee', false, clientIP);
+      await recordLoginAttempt(context.env.DB, refKey, 'attendee', false, clientIP);
       return createErrorResponse(errors.unauthorized('Invalid credentials', requestId));
     }
 
@@ -74,7 +77,7 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
       'UPDATE attendees SET password_hash = ?, must_reset_password = 0 WHERE id = ?'
     ).bind(newHash, attendee.id).run();
 
-    await recordLoginAttempt(context.env.DB, ref, 'attendee', true, clientIP);
+    await recordLoginAttempt(context.env.DB, refKey, 'attendee', true, clientIP);
 
     return createResponse({ success: true });
   } catch (error) {

--- a/functions/api/login.ts
+++ b/functions/api/login.ts
@@ -41,6 +41,12 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
 
     const { ref, password } = body as { ref: string; password: string };
     const trimmedRef = ref.trim();
+    // Reference numbers are case-insensitive at login. `refKey` (upper-cased)
+    // buckets rate-limiting/attempt records so case variants can't dodge the
+    // limiter; the DB lookup uses COLLATE NOCASE; and everything downstream
+    // (token, history, last_login) uses the *stored* canonical ref so the
+    // issued session matches what /api/me and friends query.
+    const refKey = trimmedRef.toUpperCase();
 
     // Get client IP for rate limiting
     const clientIP = context.request.headers.get('CF-Connecting-IP') ||
@@ -48,38 +54,40 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
                      'unknown';
 
     // Check rate limit (per-identifier + per-IP, fails closed on DB error)
-    const rateLimit = await checkRateLimit(context.env.DB, trimmedRef, 'attendee', clientIP);
+    const rateLimit = await checkRateLimit(context.env.DB, refKey, 'attendee', clientIP);
     if (!rateLimit.allowed) {
       return createErrorResponse(errors.rateLimited(Math.ceil((rateLimit.resetTime - Date.now()) / 1000), requestId));
     }
 
-    // Query attendee from database
+    // Query attendee from database (case-insensitive on the reference number)
     const { results } = await context.env.DB.prepare(`
       SELECT id, ref_number, password_hash, name, must_reset_password
       FROM attendees
-      WHERE ref_number = ?
+      WHERE ref_number = ? COLLATE NOCASE
     `).bind(trimmedRef).all();
 
     if (!results.length) {
       // Record failed attempt
-      await recordLoginAttempt(context.env.DB, trimmedRef, 'attendee', false, clientIP);
+      await recordLoginAttempt(context.env.DB, refKey, 'attendee', false, clientIP);
       return createErrorResponse(errors.unauthorized('Invalid credentials', requestId));
     }
 
     const attendee = results[0] as unknown as AttendeeRow;
+    // The exact ref as stored — use for token + all writes below.
+    const canonicalRef = attendee.ref_number;
 
     // Verify password
     const isValid = await verifyPassword(password, attendee.password_hash);
 
     if (!isValid) {
       // Record failed attempt
-      await recordLoginAttempt(context.env.DB, trimmedRef, 'attendee', false, clientIP);
+      await recordLoginAttempt(context.env.DB, refKey, 'attendee', false, clientIP);
       return createErrorResponse(errors.unauthorized('Invalid credentials', requestId));
     }
 
     // Record successful login and clear rate limit
-    await recordLoginAttempt(context.env.DB, trimmedRef, 'attendee', true, clientIP);
-    await clearRateLimit(context.env.DB, trimmedRef, 'attendee');
+    await recordLoginAttempt(context.env.DB, refKey, 'attendee', true, clientIP);
+    await clearRateLimit(context.env.DB, refKey, 'attendee');
 
     // Block token issuance for legacy ($retreat$) accounts that haven't reset
     // their password yet. Frontend should redirect to a "set new password"
@@ -91,19 +99,20 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
       );
     }
 
-    // Record login history and update last_login
+    // Record login history and update last_login (canonical ref)
     await context.env.DB.prepare(`
       INSERT INTO login_history (user_type, user_id, login_time)
       VALUES ('attendee', ?, CURRENT_TIMESTAMP)
-    `).bind(trimmedRef).run();
+    `).bind(canonicalRef).run();
 
     await context.env.DB.prepare(`
       UPDATE attendees SET last_login = CURRENT_TIMESTAMP
       WHERE ref_number = ?
-    `).bind(trimmedRef).run();
+    `).bind(canonicalRef).run();
 
-    // Create token with JWT secret from environment
-    const token = await generateAttendeeToken(trimmedRef, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    // Create token with JWT secret from environment (canonical ref so the
+    // session's ref matches the stored record exactly).
+    const token = await generateAttendeeToken(canonicalRef, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
 
     return createResponse({ token });
 


### PR DESCRIPTION
Two follow-up design/UX fixes.

### Case-insensitive reference number at login
Attendee login matched `ref_number` with SQLite's default case-sensitive comparison, so `ref260001` wouldn't match the stored `REF260001`. Now matches with `COLLATE NOCASE`, while carrying the **stored** canonical ref into the token, `login_history`, and `last_login` so the issued session still matches what `/api/me` and other endpoints query. Rate-limit / attempt buckets use an upper-cased key so case variants can't sidestep the limiter. The same treatment is applied to the legacy password-reset (`change-password`) flow.

### Login hero — remove side shading
Dropped the bright `border-left` accent on the scripture verse card, which read as an odd shaded strip on the hero's left edge. The verse now sits in a clean, symmetric panel.

## Test plan
- `npm run typecheck` — clean · `npm test` — 57/57
- Verified the hero verse card renders with no left accent via screenshot.
- No migration required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR)_