### PR TITLE
fix(csp): allow Cloudflare Web Analytics beacon

### DIFF
--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -6,11 +6,13 @@
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   # Font Awesome, SortableJS, html5-qrcode and the QR generator are now
   # self-hosted (/vendor, /js/vendor), so no third-party CDN is allowed for
-  # scripts/styles/fonts — only 'self' plus Stripe. 'unsafe-inline' remains on
-  # script-src (inline event handlers in a few admin/legacy templates) and
-  # style-src (inline style attributes throughout); removing those needs an
-  # incremental handler/style extraction, tracked as follow-up.
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://js.stripe.com 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: https:; connect-src 'self' https://api.stripe.com; frame-src 'self' https://js.stripe.com https://hooks.stripe.com; frame-ancestors 'none'; form-action 'self' https://checkout.stripe.com; base-uri 'self'; media-src 'self' blob:; worker-src 'self'
+  # scripts/styles/fonts — only 'self', Stripe, and Cloudflare Web Analytics
+  # (static.cloudflareinsights.com, auto-injected by Pages; its beacon posts to
+  # cloudflareinsights.com). 'unsafe-inline' remains on script-src (inline event
+  # handlers in a few admin/legacy templates) and style-src (inline style
+  # attributes throughout); removing those needs an incremental handler/style
+  # extraction, tracked as follow-up.
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://js.stripe.com https://static.cloudflareinsights.com 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: https:; connect-src 'self' https://api.stripe.com https://cloudflareinsights.com; frame-src 'self' https://js.stripe.com https://hooks.stripe.com; frame-ancestors 'none'; form-action 'self' https://checkout.stripe.com; base-uri 'self'; media-src 'self' blob:; worker-src 'self'
 
 /api/*
   Cache-Control: no-store


### PR DESCRIPTION
Follow-up to the CSP tightening in #40.

Cloudflare Pages auto-injects `static.cloudflareinsights.com/beacon.min.js` (Web Analytics), which posts to `cloudflareinsights.com`. The tightened policy didn't allow those, so the beacon was CSP-blocked (a console error + broken analytics). Add both to `script-src` / `connect-src`.

Note: it was already blocked under the previous CDN-based policy too — this just fixes it properly while we're here. No app functionality was affected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR)_