### PR TITLE
feat(admin): Activity Teams balance heatmap, roster view + CSV export

### DIFF
--- a/frontend/public/css/components.css
+++ b/frontend/public/css/components.css
@@ -2633,3 +2633,93 @@ select.form-input option,
   line-height: 1.5;
 }
 .checkin-qr-hint i { color: #fbbf24; }
+
+/* ===================== Activity Teams — balance heatmap ===================== */
+.team-balance-wrap { padding: 0.25rem; }
+
+.heatmap-table { border-collapse: separate; border-spacing: 0; font-size: 0.8rem; }
+.heatmap-table th,
+.heatmap-table td { padding: 0.4rem 0.55rem; }
+.heatmap-table thead th {
+  color: var(--text-secondary);
+  font-weight: 600;
+  background: var(--bg-secondary, rgba(255,255,255,0.03));
+}
+.heatmap-table td[style*="sticky"],
+.heatmap-table th[style*="sticky"] {
+  background: var(--bg-card, #1b1b2b);
+  z-index: 1;
+}
+.heat-cell {
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  border-radius: 4px;
+  color: var(--text-primary);
+  transition: outline 0.1s;
+}
+.heat-cell:hover { outline: 1px solid rgba(255,255,255,0.35); }
+.heat-total-row td {
+  border-top: 2px solid var(--glass-border, rgba(255,255,255,0.12));
+  font-weight: 600;
+}
+.team-balance-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin: 0.75rem 0.25rem 0.25rem;
+  padding: 0.6rem 0.8rem;
+  border-radius: 8px;
+  background: rgba(59,130,246,0.10);
+  border: 1px solid rgba(59,130,246,0.25);
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+.team-balance-note i { color: #60a5fa; margin-top: 0.15rem; }
+
+/* Compact per-team balance bar in the teams table */
+.balance-bar {
+  display: flex;
+  height: 8px;
+  width: 100%;
+  border-radius: 4px;
+  overflow: hidden;
+  background: rgba(255,255,255,0.06);
+  margin-bottom: 3px;
+}
+.balance-bar > span { display: block; min-width: 3px; }
+
+/* Small inline chips (age band / gender) */
+.mini-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+/* Expandable member roster */
+.roster-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: 0.4rem;
+  padding: 0.5rem 0.25rem;
+}
+.roster-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.55rem;
+  border-radius: 8px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--glass-border, rgba(255,255,255,0.08));
+  font-size: 0.78rem;
+}
+.roster-name { font-weight: 600; color: var(--text-primary); }
+.roster-ref { font-size: 0.68rem; color: var(--text-tertiary); margin-left: auto; }
+.roster-flag { font-size: 0.72rem; color: var(--text-secondary); }
+

--- a/frontend/public/js/components/admin-dashboard.js
+++ b/frontend/public/js/components/admin-dashboard.js
@@ -1649,16 +1649,186 @@ const AdminDashboard = {
             console.error('Failed to load activity teams:', error);
             this.data.activityTeams = [];
         }
+        // Load the demographic breakdown in parallel with the base list; it
+        // powers the balance heatmap and the per-team roster chips.
+        await this.loadTeamBreakdown();
+        this._bindTeamBalanceControls();
+    },
+
+    async loadTeamBreakdown() {
+        try {
+            const res = await API.get('/admin/activity-teams/breakdown');
+            this.data.teamBreakdown = res || null;
+            this._teamBreakdownById = {};
+            (res?.teams || []).forEach(t => { this._teamBreakdownById[t.id] = t; });
+        } catch (error) {
+            console.error('Failed to load team breakdown:', error);
+            this.data.teamBreakdown = null;
+            this._teamBreakdownById = {};
+        }
+        this.renderTeamBalanceHeatmap();
+    },
+
+    // Wire the Export CSV + Refresh buttons once (guarded flags — the tab HTML
+    // is static so the nodes persist across re-renders).
+    _bindTeamBalanceControls() {
+        const exportBtn = document.getElementById('export-teams-csv-btn');
+        if (exportBtn && !exportBtn._bound) {
+            exportBtn._bound = true;
+            exportBtn.addEventListener('click', () => this.exportTeamsCsv());
+        }
+        const refreshBtn = document.getElementById('refresh-team-balance-btn');
+        if (refreshBtn && !refreshBtn._bound) {
+            refreshBtn._bound = true;
+            refreshBtn.addEventListener('click', async () => {
+                refreshBtn.disabled = true;
+                await this.loadActivityTeams();
+                this.updateActivityTeamsDisplay();
+                refreshBtn.disabled = false;
+            });
+        }
+    },
+
+    async exportTeamsCsv() {
+        const btn = document.getElementById('export-teams-csv-btn');
+        try {
+            if (btn) { btn.disabled = true; btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Exporting…'; }
+            const response = await fetch('/api/admin/export?type=activity-teams', {
+                headers: { 'Authorization': `Bearer ${Auth.getToken('admin')}` }
+            });
+            if (!response.ok) throw new Error('Export failed');
+            const blob = await response.blob();
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `activity-teams-${new Date().toISOString().split('T')[0]}.csv`;
+            a.click();
+            URL.revokeObjectURL(url);
+            Utils.showAlert('Activity teams exported', 'success');
+        } catch (err) {
+            Utils.showAlert('Export failed: ' + (err.message || err), 'error');
+        } finally {
+            if (btn) { btn.disabled = false; btn.innerHTML = '<i class="fas fa-file-csv"></i> Export CSV'; }
+        }
+    },
+
+    // Render the teams × demographics balance matrix. Each demographic cell is
+    // shaded by that bucket's share of the team, so imbalances jump out.
+    renderTeamBalanceHeatmap() {
+        const wrap = document.getElementById('team-balance-heatmap');
+        if (!wrap) return;
+
+        const bd = this.data.teamBreakdown;
+        if (!bd || !bd.teams || bd.teams.length === 0) {
+            wrap.innerHTML = `<div style="padding: 1.5rem; text-align: center; color: var(--text-secondary);">
+                <i class="fas fa-people-group" style="font-size: 1.5rem; display:block; margin-bottom:0.5rem;"></i>
+                No teams yet — create a team to see its balance.</div>`;
+            return;
+        }
+
+        // Column groups: [key, label, group-hue rgb]
+        const AGE = '99, 102, 241';      // indigo
+        const GEN = '236, 72, 153';      // pink
+        const FLG = '245, 158, 11';      // amber
+        const cols = [
+            { key: 'adult', group: 'age', label: 'Adults', rgb: AGE },
+            { key: 'child', group: 'age', label: 'Children', rgb: AGE },
+            { key: 'under5', group: 'age', label: 'Under 5', rgb: AGE },
+            { key: 'unknown', group: 'age', label: 'Age ?', rgb: '120,120,140' },
+            { key: 'male', group: 'gender', label: 'Male', rgb: GEN },
+            { key: 'female', group: 'gender', label: 'Female', rgb: GEN },
+            { key: 'genderUnknown', group: 'gender', label: 'Gender ?', rgb: '120,120,140' },
+            { key: 'dietary', group: 'flags', label: 'Dietary', rgb: FLG },
+            { key: 'medical', group: 'flags', label: 'Medical', rgb: FLG },
+            { key: 'accessibility', group: 'flags', label: 'Access', rgb: FLG },
+            { key: 'checked_in', group: 'flags', label: 'In', rgb: '16,185,129' },
+        ];
+
+        const valueFor = (t, key) => {
+            if (key === 'genderUnknown') return t.gender.unknown;
+            if (['adult', 'child', 'under5', 'unknown'].includes(key)) return t.age[key];
+            if (['male', 'female'].includes(key)) return t.gender[key];
+            return t.flags[key];
+        };
+
+        const cell = (count, denom, rgb) => {
+            const share = denom > 0 ? count / denom : 0;
+            const intensity = count === 0 ? 0 : (0.14 + 0.66 * share).toFixed(3);
+            const bg = count === 0 ? 'transparent' : `rgba(${rgb}, ${intensity})`;
+            const txt = count === 0 ? '<span style="color:var(--text-tertiary)">·</span>' : count;
+            const title = denom > 0 ? `${count} of ${denom} (${Math.round(share * 100)}%)` : `${count}`;
+            return `<td class="heat-cell" style="background:${bg};" title="${title}">${txt}</td>`;
+        };
+
+        const headerGroup = (label, span, rgb) =>
+            `<th colspan="${span}" style="text-align:center; border-bottom:2px solid rgba(${rgb},0.5);">${label}</th>`;
+
+        const rowFor = (t, isTotal = false) => {
+            const denom = t.member_count;
+            const nameCell = isTotal
+                ? `<td style="position:sticky; left:0;"><strong>All teams</strong></td>`
+                : `<td style="position:sticky; left:0;"><span style="display:inline-flex; align-items:center; gap:0.4rem;">
+                       <span class="team-color-dot" style="background:${Utils.escapeHtml(t.color)};"></span>
+                       <span style="white-space:nowrap;">${Utils.escapeHtml(t.name)}</span></span></td>`;
+            const countCell = `<td style="text-align:center;"><strong>${t.member_count}</strong></td>`;
+            const cells = cols.map(c => cell(valueFor(t, c.key), denom, c.rgb)).join('');
+            return `<tr class="${isTotal ? 'heat-total-row' : ''}">${nameCell}${countCell}${cells}</tr>`;
+        };
+
+        const genderNote = !bd.gender_available || (bd.totals.gender.male + bd.totals.gender.female === 0)
+            ? `<div class="team-balance-note"><i class="fas fa-circle-info"></i>
+                 Gender isn't recorded for these attendees yet. Set it on an attendee's profile (Attendees → edit)
+                 to populate the Male / Female split.</div>`
+            : '';
+
+        wrap.innerHTML = `
+            <div class="table-container">
+              <table class="table heatmap-table">
+                <thead>
+                  <tr>
+                    <th rowspan="2" style="position:sticky; left:0;">Team</th>
+                    <th rowspan="2" style="text-align:center;">Size</th>
+                    ${headerGroup('Age', 4, AGE)}
+                    ${headerGroup('Gender', 3, GEN)}
+                    ${headerGroup('Needs & status', 4, FLG)}
+                  </tr>
+                  <tr>
+                    ${cols.map(c => `<th style="text-align:center; font-size:0.7rem; white-space:nowrap;">${c.label}</th>`).join('')}
+                  </tr>
+                </thead>
+                <tbody>
+                  ${bd.teams.map(t => rowFor(t)).join('')}
+                  ${rowFor(bd.totals, true)}
+                </tbody>
+              </table>
+            </div>
+            ${genderNote}`;
     },
 
     updateActivityTeamsDisplay() {
         const tbody = document.getElementById('activity-teams-table-body');
         if (!tbody) return;
 
+        // Delegated expand/collapse for the member rosters — bound once.
+        if (!tbody._expandBound) {
+            tbody._expandBound = true;
+            tbody.addEventListener('click', (e) => {
+                const toggle = e.target.closest('.team-expand-toggle');
+                if (!toggle) return;
+                const id = toggle.dataset.id;
+                const roster = tbody.querySelector(`.team-roster-row[data-id="${id}"]`);
+                if (roster) {
+                    const open = roster.classList.toggle('hidden');
+                    const icon = toggle.querySelector('i');
+                    if (icon) icon.className = open ? 'fas fa-chevron-right' : 'fas fa-chevron-down';
+                }
+            });
+        }
+
         if (this.data.activityTeams.length === 0) {
             tbody.innerHTML = `
                 <tr>
-                    <td colspan="5" style="text-align: center; color: var(--text-secondary); padding: 2rem;">
+                    <td colspan="6" style="text-align: center; color: var(--text-secondary); padding: 2rem;">
                         <i class="fas fa-people-group" style="font-size: 2rem; margin-bottom: 1rem; display: block;"></i>
                         No activity teams created yet
                     </td>
@@ -1666,19 +1836,84 @@ const AdminDashboard = {
             return;
         }
 
+        const bandChip = (band) => {
+            const map = {
+                adult: ['Adult', 'rgba(99,102,241,0.18)', '#c7d2fe'],
+                child: ['Child', 'rgba(59,130,246,0.18)', '#bfdbfe'],
+                under5: ['Under 5', 'rgba(14,165,233,0.20)', '#bae6fd'],
+                unknown: ['Age ?', 'rgba(120,120,140,0.18)', 'var(--text-tertiary)'],
+            };
+            const [label, bg, fg] = map[band] || map.unknown;
+            return `<span class="mini-chip" style="background:${bg}; color:${fg};">${label}</span>`;
+        };
+        const genderChip = (g) => {
+            if (g === 'male') return `<span class="mini-chip" style="background:rgba(59,130,246,0.18); color:#bfdbfe;"><i class="fas fa-mars"></i></span>`;
+            if (g === 'female') return `<span class="mini-chip" style="background:rgba(236,72,153,0.18); color:#fbcfe8;"><i class="fas fa-venus"></i></span>`;
+            return '';
+        };
+
         tbody.innerHTML = this.data.activityTeams.map(team => {
+            const bd = this._teamBreakdownById ? this._teamBreakdownById[team.id] : null;
+            const color = team.color || '#8b5cf6';
+
+            // Compact balance summary bar (age + gender) from the breakdown.
+            let balanceCell = '<span style="color: var(--text-tertiary);">—</span>';
+            if (bd && bd.member_count > 0) {
+                const a = bd.age, g = bd.gender;
+                const seg = (n, rgb) => n > 0 ? `<span style="flex:${n}; background:rgba(${rgb},0.75);" title="${n}"></span>` : '';
+                const ageBar = `<div class="balance-bar">
+                    ${seg(a.adult, '99,102,241')}${seg(a.child, '59,130,246')}${seg(a.under5, '14,165,233')}${seg(a.unknown, '120,120,140')}
+                </div>`;
+                const genderBar = (g.male + g.female) > 0 ? `<div class="balance-bar">
+                    ${seg(g.male, '59,130,246')}${seg(g.female, '236,72,153')}${seg(g.unknown, '120,120,140')}
+                </div>` : '';
+                balanceCell = `<div style="min-width:120px;">
+                    ${ageBar}${genderBar}
+                    <div style="font-size:0.65rem; color:var(--text-tertiary); margin-top:2px;">
+                        ${a.adult}A · ${a.child + a.under5}C${(g.male + g.female) > 0 ? ` · ${g.male}M/${g.female}F` : ''}
+                    </div>
+                </div>`;
+            }
+
             const memberList = team.members && team.members.length > 0
-                ? team.members.slice(0, 5).join(', ') + (team.members.length > 5 ? ` +${team.members.length - 5} more` : '')
+                ? team.members.slice(0, 4).join(', ') + (team.members.length > 4 ? ` +${team.members.length - 4} more` : '')
                 : '<span style="color: var(--text-tertiary);">No members</span>';
 
-            const color = team.color || '#8b5cf6';
+            // Roster row (hidden by default) with a chip per member.
+            let rosterHtml = '';
+            if (bd && bd.members && bd.members.length > 0) {
+                const chips = bd.members.map(m => `
+                    <div class="roster-chip">
+                        <span class="roster-name">${Utils.escapeHtml(m.name)}</span>
+                        <span class="roster-ref">${Utils.escapeHtml(m.ref_number)}</span>
+                        ${bandChip(m.age_band)}${genderChip(m.gender)}
+                        ${m.dietary ? '<i class="fas fa-utensils roster-flag" title="Dietary need"></i>' : ''}
+                        ${m.medical ? '<i class="fas fa-notes-medical roster-flag" title="Medical note"></i>' : ''}
+                        ${m.accessibility ? '<i class="fas fa-wheelchair roster-flag" title="Accessibility need"></i>' : ''}
+                        ${m.checked_in ? '<i class="fas fa-circle-check roster-flag" style="color:var(--success);" title="Checked in"></i>' : ''}
+                    </div>`).join('');
+                rosterHtml = `
+                    <tr class="team-roster-row hidden" data-id="${team.id}">
+                        <td colspan="6" style="background:rgba(255,255,255,0.02);">
+                            <div class="roster-grid">${chips}</div>
+                        </td>
+                    </tr>`;
+            }
+
+            const hasRoster = bd && bd.members && bd.members.length > 0;
             return `
                 <tr>
-                    <td><span style="display: inline-flex; align-items: center; gap: 0.5rem;"><span class="team-color-dot" style="background: ${Utils.escapeHtml(color)};"></span><strong>${Utils.escapeHtml(team.name)}</strong></span></td>
-                    <td style="max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${Utils.escapeHtml(team.description || '-')}</td>
+                    <td style="text-align:center;">
+                        ${hasRoster ? `<button class="btn-icon team-expand-toggle" data-id="${team.id}" title="Show members"><i class="fas fa-chevron-right"></i></button>` : ''}
+                    </td>
+                    <td>
+                        <span style="display: inline-flex; align-items: center; gap: 0.5rem;"><span class="team-color-dot" style="background: ${Utils.escapeHtml(color)};"></span><strong>${Utils.escapeHtml(team.name)}</strong></span>
+                        ${team.description ? `<div style="font-size:0.7rem; color:var(--text-tertiary); margin-top:0.15rem; max-width:220px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">${Utils.escapeHtml(team.description)}</div>` : ''}
+                    </td>
                     <td>${team.leader_name
                         ? `<span class="badge badge-primary"><i class="fas fa-crown"></i> ${Utils.escapeHtml(team.leader_name)}</span>`
                         : '<span style="color: var(--text-tertiary);">None</span>'}</td>
+                    <td>${balanceCell}</td>
                     <td>
                         <span class="badge badge-secondary">${team.member_count} members</span>
                         <div style="font-size: 0.7rem; color: var(--text-tertiary); margin-top: 0.25rem; max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${memberList}</div>
@@ -1693,7 +1928,8 @@ const AdminDashboard = {
                             </button>
                         </div>
                     </td>
-                </tr>`;
+                </tr>
+                ${rosterHtml}`;
         }).join('');
     },
 

--- a/frontend/public/js/components/attendee-management.js
+++ b/frontend/public/js/components/attendee-management.js
@@ -64,6 +64,8 @@ const AttendeeManagement = {
             document.getElementById('attendee-first-name').value = editData.first_name || '';
             document.getElementById('attendee-last-name').value = editData.last_name || '';
             document.getElementById('attendee-dob').value = editData.date_of_birth || '';
+            const genderSelect = document.getElementById('attendee-gender');
+            if (genderSelect) genderSelect.value = (editData.gender || '').toLowerCase();
             document.getElementById('attendee-ref').value = editData.ref_number || '';
             document.getElementById('attendee-payment').value = editData.payment_due || 0;
             document.getElementById('attendee-payment-option').value = editData.payment_option || 'full';
@@ -158,7 +160,7 @@ const AttendeeManagement = {
         }
         
         // Convert empty strings to null for optional fields
-        ['room_id', 'group_id', 'email', 'first_name', 'last_name', 'date_of_birth'].forEach(field => {
+        ['room_id', 'group_id', 'email', 'first_name', 'last_name', 'date_of_birth', 'gender'].forEach(field => {
             if (data[field] === '') {
                 data[field] = null;
             }

--- a/frontend/public/templates/admin-dashboard.html
+++ b/frontend/public/templates/admin-dashboard.html
@@ -642,6 +642,24 @@
 
     <!-- Activity Teams Tab -->
     <div class="tab-content" id="activity-teams-tab">
+        <!-- Team Balance heatmap -->
+        <div class="data-table" style="margin-bottom: 1.5rem;">
+            <div class="table-header">
+                <h3 class="table-title"><i class="fas fa-scale-balanced"></i> Team Balance</h3>
+                <div style="display: flex; gap: 0.75rem; align-items: center;">
+                    <button class="btn btn-sm btn-ghost" id="refresh-team-balance-btn" title="Refresh balance">
+                        <i class="fas fa-sync-alt"></i>
+                    </button>
+                    <button class="btn btn-sm btn-secondary" id="export-teams-csv-btn">
+                        <i class="fas fa-file-csv"></i> Export CSV
+                    </button>
+                </div>
+            </div>
+            <div id="team-balance-heatmap" class="team-balance-wrap">
+                <div class="loading-placeholder"><i class="fas fa-spinner fa-spin"></i> Loading team balance…</div>
+            </div>
+        </div>
+
         <div class="data-table">
             <div class="table-header">
                 <h3 class="table-title">Activity Teams</h3>
@@ -655,16 +673,17 @@
                 <table class="table">
                     <thead>
                         <tr>
+                            <th style="width: 2.5rem;"></th>
                             <th>Team Name</th>
-                            <th>Description</th>
                             <th>Leader</th>
+                            <th>Balance</th>
                             <th>Members</th>
                             <th>Actions</th>
                         </tr>
                     </thead>
                     <tbody id="activity-teams-table-body">
                         <tr>
-                            <td colspan="5" class="loading-placeholder">
+                            <td colspan="6" class="loading-placeholder">
                                 <i class="fas fa-spinner fa-spin"></i> Loading activity teams...
                             </td>
                         </tr>

--- a/frontend/public/templates/modals/attendee-modal.html
+++ b/frontend/public/templates/modals/attendee-modal.html
@@ -34,6 +34,14 @@
                         <label for="attendee-dob" class="form-label">Date of Birth</label>
                         <input type="date" id="attendee-dob" name="date_of_birth" class="form-input">
                     </div>
+                    <div class="form-group">
+                        <label for="attendee-gender" class="form-label">Gender</label>
+                        <select id="attendee-gender" name="gender" class="form-input">
+                            <option value="">Prefer not to say / unknown</option>
+                            <option value="male">Male</option>
+                            <option value="female">Female</option>
+                        </select>
+                    </div>
                 </div>
 
                 <div class="form-row">

--- a/functions/_shared/team-demographics.ts
+++ b/functions/_shared/team-demographics.ts
@@ -1,0 +1,236 @@
+// Shared demographics helpers for the Activity Teams balance views (the admin
+// heatmap and the CSV export). Centralises three things so both endpoints agree
+// exactly: the age-band thresholds, the gender normalisation, and the
+// defensive member query that works whether or not the optional `gender`
+// column (migration 031) has been applied yet.
+
+import type { D1Database } from '@cloudflare/workers-types';
+import { ageFromDateOfBirth } from './names.js';
+
+// Age bands derived from date_of_birth. Kept deliberately coarse and standard
+// so the balance read is meaningful to a room/pastoral planner:
+//   under5 : 0–4   (need close supervision / cots / different sleeping)
+//   child  : 5–17
+//   adult  : 18+
+//   unknown: no usable date_of_birth on file
+export type AgeBand = 'adult' | 'child' | 'under5' | 'unknown';
+
+export function ageBand(dob: string | null | undefined, asOf?: Date): AgeBand {
+  const age = ageFromDateOfBirth(dob, asOf);
+  if (age === null) return 'unknown';
+  if (age < 5) return 'under5';
+  if (age < 18) return 'child';
+  return 'adult';
+}
+
+export const AGE_BAND_LABELS: Record<AgeBand, string> = {
+  adult: 'Adult (18+)',
+  child: 'Child (5–17)',
+  under5: 'Under 5',
+  unknown: 'Age unknown',
+};
+
+// Gender is stored lower-case; anything else (including NULL) is "unknown".
+export type Gender = 'male' | 'female' | 'unknown';
+
+export function normaliseGender(g: unknown): Gender {
+  if (typeof g !== 'string') return 'unknown';
+  const v = g.trim().toLowerCase();
+  if (v === 'male' || v === 'm') return 'male';
+  if (v === 'female' || v === 'f') return 'female';
+  return 'unknown';
+}
+
+// One row per (team, member). Team meta is repeated on each row so callers can
+// group in JS without a second round-trip.
+export interface TeamMemberRow {
+  team_id: number;
+  team_name: string;
+  team_color: string | null;
+  leader_id: number | null;
+  leader_name: string | null;
+  attendee_id: number;
+  name: string;
+  ref_number: string;
+  email: string | null;
+  phone: string | null;
+  date_of_birth: string | null;
+  gender: string | null;
+  dietary_requirements: string | null;
+  medical_conditions: string | null;
+  accessibility_needs: string | null;
+  checked_in: number | null;
+  group_name: string | null;
+}
+
+// Fetch every team membership with the attendee attributes the balance views
+// need. Falls back gracefully if the `gender` column hasn't been migrated yet:
+// on a "no such column" error we re-run selecting NULL AS gender and report
+// genderAvailable = false so the UI can explain the empty split.
+export async function fetchTeamMemberRows(
+  DB: D1Database
+): Promise<{ rows: TeamMemberRow[]; genderAvailable: boolean }> {
+  const base = (genderExpr: string) => `
+    SELECT
+      t.id            AS team_id,
+      t.name          AS team_name,
+      t.color         AS team_color,
+      t.leader_id     AS leader_id,
+      leader.name     AS leader_name,
+      a.id            AS attendee_id,
+      a.name          AS name,
+      a.ref_number    AS ref_number,
+      a.email         AS email,
+      a.phone         AS phone,
+      a.date_of_birth AS date_of_birth,
+      ${genderExpr}   AS gender,
+      a.dietary_requirements AS dietary_requirements,
+      a.medical_conditions   AS medical_conditions,
+      a.accessibility_needs  AS accessibility_needs,
+      a.checked_in    AS checked_in,
+      g.name          AS group_name
+    FROM activity_team_members m
+    JOIN activity_teams t ON m.team_id = t.id
+    JOIN attendees a ON m.attendee_id = a.id
+    LEFT JOIN attendees leader ON t.leader_id = leader.id
+    LEFT JOIN groups g ON a.group_id = g.id
+    ORDER BY t.name, a.name
+  `;
+
+  try {
+    const { results } = await DB.prepare(base('a.gender')).all();
+    return { rows: results as unknown as TeamMemberRow[], genderAvailable: true };
+  } catch (err) {
+    // Most likely: gender column not migrated yet. Retry without it rather than
+    // failing the whole balance view.
+    if (/no such column|gender/i.test(String((err as Error)?.message))) {
+      const { results } = await DB.prepare(base('NULL')).all();
+      return { rows: results as unknown as TeamMemberRow[], genderAvailable: false };
+    }
+    throw err;
+  }
+}
+
+export interface TeamBreakdown {
+  id: number;
+  name: string;
+  color: string;
+  leader_id: number | null;
+  leader_name: string | null;
+  member_count: number;
+  age: Record<AgeBand, number>;
+  gender: Record<Gender, number>;
+  flags: { dietary: number; medical: number; accessibility: number; checked_in: number };
+  members: Array<{
+    id: number;
+    name: string;
+    ref_number: string;
+    age: number | null;
+    age_band: AgeBand;
+    gender: Gender;
+    dietary: boolean;
+    medical: boolean;
+    accessibility: boolean;
+    checked_in: boolean;
+    group_name: string | null;
+  }>;
+}
+
+const DEFAULT_TEAM_COLOR = '#8b5cf6';
+
+function emptyAge(): Record<AgeBand, number> {
+  return { adult: 0, child: 0, under5: 0, unknown: 0 };
+}
+function emptyGender(): Record<Gender, number> {
+  return { male: 0, female: 0, unknown: 0 };
+}
+
+const hasText = (v: string | null | undefined): boolean =>
+  typeof v === 'string' && v.trim() !== '' && v.trim().toLowerCase() !== 'none';
+
+// Group the flat rows into per-team breakdowns plus an all-teams totals block.
+// `allTeams` (id/name/color/leader) is passed in so teams with zero members
+// still appear with empty counts rather than vanishing from the view.
+export function buildBreakdown(
+  allTeams: Array<{ id: number; name: string; color: string | null; leader_id: number | null; leader_name: string | null }>,
+  rows: TeamMemberRow[],
+  asOf?: Date
+): { teams: TeamBreakdown[]; totals: Omit<TeamBreakdown, 'members' | 'id' | 'name' | 'color' | 'leader_id' | 'leader_name'> } {
+  const byTeam = new Map<number, TeamBreakdown>();
+
+  for (const t of allTeams) {
+    byTeam.set(t.id, {
+      id: t.id,
+      name: t.name,
+      color: t.color || DEFAULT_TEAM_COLOR,
+      leader_id: t.leader_id,
+      leader_name: t.leader_name,
+      member_count: 0,
+      age: emptyAge(),
+      gender: emptyGender(),
+      flags: { dietary: 0, medical: 0, accessibility: 0, checked_in: 0 },
+      members: [],
+    });
+  }
+
+  const totals = {
+    member_count: 0,
+    age: emptyAge(),
+    gender: emptyGender(),
+    flags: { dietary: 0, medical: 0, accessibility: 0, checked_in: 0 },
+  };
+
+  for (const r of rows) {
+    let team = byTeam.get(r.team_id);
+    if (!team) {
+      // Team not in allTeams (shouldn't happen) — synthesise it defensively.
+      team = {
+        id: r.team_id, name: r.team_name, color: r.team_color || DEFAULT_TEAM_COLOR,
+        leader_id: r.leader_id, leader_name: r.leader_name, member_count: 0,
+        age: emptyAge(), gender: emptyGender(),
+        flags: { dietary: 0, medical: 0, accessibility: 0, checked_in: 0 }, members: [],
+      };
+      byTeam.set(r.team_id, team);
+    }
+
+    const band = ageBand(r.date_of_birth, asOf);
+    const gender = normaliseGender(r.gender);
+    const dietary = hasText(r.dietary_requirements);
+    const medical = hasText(r.medical_conditions);
+    const accessibility = hasText(r.accessibility_needs);
+    const checkedIn = !!r.checked_in;
+
+    team.member_count++;
+    team.age[band]++;
+    team.gender[gender]++;
+    if (dietary) team.flags.dietary++;
+    if (medical) team.flags.medical++;
+    if (accessibility) team.flags.accessibility++;
+    if (checkedIn) team.flags.checked_in++;
+
+    totals.member_count++;
+    totals.age[band]++;
+    totals.gender[gender]++;
+    if (dietary) totals.flags.dietary++;
+    if (medical) totals.flags.medical++;
+    if (accessibility) totals.flags.accessibility++;
+    if (checkedIn) totals.flags.checked_in++;
+
+    team.members.push({
+      id: r.attendee_id,
+      name: r.name,
+      ref_number: r.ref_number,
+      age: ageFromDateOfBirth(r.date_of_birth, asOf),
+      age_band: band,
+      gender,
+      dietary,
+      medical,
+      accessibility,
+      checked_in: checkedIn,
+      group_name: r.group_name,
+    });
+  }
+
+  const teams = Array.from(byTeam.values()).sort((a, b) => a.name.localeCompare(b.name));
+  return { teams, totals };
+}

--- a/functions/api/admin/activity-teams/breakdown.ts
+++ b/functions/api/admin/activity-teams/breakdown.ts
@@ -1,0 +1,60 @@
+// GET /api/admin/activity-teams/breakdown
+//
+// Per-team demographic breakdown powering the admin "Team Balance" heatmap:
+// age bands (from date_of_birth), gender split (from the optional gender
+// column), and pastoral flags (dietary / medical / accessibility / checked-in),
+// plus the full member roster per team. Teams with zero members are included
+// with empty counts.
+//
+// Static route file — takes precedence over the sibling [id].ts dynamic route
+// for the literal path /activity-teams/breakdown.
+
+import type { PagesContext } from '../../../_shared/types.js';
+import { createResponse, checkAdminAuth, handleCORS } from '../../../_shared/auth.js';
+import { errors, createErrorResponse, generateRequestId, handleError } from '../../../_shared/errors.js';
+import { fetchTeamMemberRows, buildBreakdown } from '../../../_shared/team-demographics.js';
+
+export async function onRequestOptions(): Promise<Response> {
+  return handleCORS();
+}
+
+export async function onRequestGet(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+
+  try {
+    const admin = await checkAdminAuth(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) {
+      return createErrorResponse(errors.unauthorized('Invalid or expired token', requestId));
+    }
+
+    // All teams first, so empty teams still show up in the balance grid.
+    const { results: teamRows } = await context.env.DB.prepare(`
+      SELECT t.id, t.name, t.color, t.leader_id, leader.name AS leader_name
+      FROM activity_teams t
+      LEFT JOIN attendees leader ON t.leader_id = leader.id
+      ORDER BY t.name
+    `).all();
+
+    const allTeams = (teamRows as Record<string, unknown>[]).map(t => ({
+      id: t.id as number,
+      name: t.name as string,
+      color: (t.color as string | null) ?? null,
+      leader_id: (t.leader_id as number | null) ?? null,
+      leader_name: (t.leader_name as string | null) ?? null,
+    }));
+
+    const { rows, genderAvailable } = await fetchTeamMemberRows(context.env.DB);
+    const { teams, totals } = buildBreakdown(allTeams, rows);
+
+    return createResponse({
+      teams,
+      totals,
+      team_count: teams.length,
+      gender_available: genderAvailable,
+    });
+
+  } catch (error) {
+    console.error(`[${requestId}] Error building activity-team breakdown:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}

--- a/functions/api/admin/attendees/[id].ts
+++ b/functions/api/admin/attendees/[id].ts
@@ -76,6 +76,17 @@ export async function onRequestGet(context: PagesContext<IdParams>): Promise<Res
 
     const attendee = results[0] as unknown as AttendeeRow;
 
+    // Gender lives in an optional column (migration 031). Fetch it separately
+    // and defensively so this endpoint keeps working if the column isn't there
+    // yet — the edit modal simply shows "unknown" until it's migrated/filled.
+    let gender: string | null = null;
+    try {
+      const g = await context.env.DB.prepare('SELECT gender FROM attendees WHERE id = ?').bind(id).first();
+      gender = ((g?.gender as string | null) ?? null);
+    } catch {
+      gender = null;
+    }
+
     const formattedResult = {
       id: attendee.id,
       ref_number: attendee.ref_number,
@@ -84,6 +95,7 @@ export async function onRequestGet(context: PagesContext<IdParams>): Promise<Res
       first_name: attendee.first_name,
       last_name: attendee.last_name,
       date_of_birth: attendee.date_of_birth,
+      gender,
       payment_due: attendee.payment_due || 0,
       payment_option: attendee.payment_option || 'full',
       room_id: attendee.room_id,
@@ -181,7 +193,7 @@ export async function onRequestPut(context: PagesContext<IdParams>): Promise<Res
     }
 
     // Build dynamic UPDATE query
-    const allowedFields = ['name', 'first_name', 'last_name', 'date_of_birth', 'email', 'ref_number', 'room_id', 'group_id', 'payment_due', 'payment_option', 'password'];
+    const allowedFields = ['name', 'first_name', 'last_name', 'date_of_birth', 'gender', 'email', 'ref_number', 'room_id', 'group_id', 'payment_due', 'payment_option', 'password'];
     const updateFields: string[] = [];
     const updateValues: (string | number | null)[] = [];
 
@@ -193,6 +205,11 @@ export async function onRequestPut(context: PagesContext<IdParams>): Promise<Res
             updateFields.push('password_hash = ?');
             updateValues.push(hashedPassword);
           }
+        } else if (key === 'gender') {
+          // Normalise to the stored lower-case form; anything else clears it.
+          const g = typeof value === 'string' ? value.trim().toLowerCase() : '';
+          updateFields.push('gender = ?');
+          updateValues.push(g === 'male' || g === 'female' ? g : null);
         } else {
           updateFields.push(`${key} = ?`);
           updateValues.push(value === '' ? null : value as string | number | null);
@@ -207,7 +224,34 @@ export async function onRequestPut(context: PagesContext<IdParams>): Promise<Res
     updateValues.push(id);
 
     const updateQuery = `UPDATE attendees SET ${updateFields.join(', ')} WHERE id = ?`;
-    const result = await context.env.DB.prepare(updateQuery).bind(...updateValues).run();
+    let result;
+    try {
+      result = await context.env.DB.prepare(updateQuery).bind(...updateValues).run();
+    } catch (err) {
+      // Pre-migration safety: if the optional `gender` column (migration 031)
+      // hasn't been applied yet, retry the update without it so every other
+      // field still saves instead of the whole edit failing.
+      const msg = String((err as Error)?.message || '');
+      const genderIdx = updateFields.findIndex(f => f.startsWith('gender ='));
+      if (genderIdx !== -1 && /no such column|gender/i.test(msg)) {
+        const fields2 = updateFields.filter((_, i) => i !== genderIdx);
+        const values2 = updateValues.filter((_, i) => i !== genderIdx); // id stays at the tail
+        if (fields2.length === 0) {
+          // Only gender was being set and the column is missing — treat as a
+          // no-op success rather than surfacing an error to the admin.
+          return createResponse({
+            success: true,
+            message: 'Attendee updated successfully',
+            id: parseInt(id),
+            warning: 'Gender not stored yet — pending database migration.',
+          });
+        }
+        const query2 = `UPDATE attendees SET ${fields2.join(', ')} WHERE id = ?`;
+        result = await context.env.DB.prepare(query2).bind(...values2).run();
+      } else {
+        throw err;
+      }
+    }
 
     if (!result.success) {
       throw new Error('Failed to update attendee');

--- a/functions/api/admin/export.ts
+++ b/functions/api/admin/export.ts
@@ -3,6 +3,7 @@ import { checkAdminAuth, handleCORS } from '../../_shared/auth.js';
 import { errors, createErrorResponse, generateRequestId, handleError } from '../../_shared/errors.js';
 import { splitFullName, ageFromDateOfBirth } from '../../_shared/names.js';
 import { csvCell } from '../../_shared/sanitize.js';
+import { fetchTeamMemberRows, ageBand, normaliseGender, AGE_BAND_LABELS } from '../../_shared/team-demographics.js';
 
 // Hard cap on rows returned from a single export. D1 has its own row limits,
 // and walking everything in one query is fine for the foreseeable retreat
@@ -137,6 +138,36 @@ export async function onRequestGet(context: PagesContext): Promise<Response> {
         csv += row([r.id, r.name, r.email, r.phone, r.status, r.payment_option, r.total_amount, r.member_count, r.submitted_at, r.reviewed_at]);
       }
       filename = `registrations-${new Date().toISOString().split('T')[0]}.csv`;
+
+    } else if (type === 'activity-teams') {
+      // One row per team membership, with the member's demographics. Mirrors
+      // the admin balance heatmap so admins can pivot the same data offline.
+      const { rows } = await fetchTeamMemberRows(context.env.DB);
+
+      const genderLabel: Record<string, string> = { male: 'Male', female: 'Female', unknown: 'Unknown' };
+      csv = 'Team,Team Leader,Member Name,Reference,Email,Phone,Age,Age Band,Gender,Group,Dietary,Medical,Accessibility,Checked In\n';
+      for (const r of rows) {
+        const age = ageFromDateOfBirth(r.date_of_birth);
+        const band = ageBand(r.date_of_birth);
+        csv += row([
+          r.team_name,
+          r.leader_name,
+          r.name,
+          r.ref_number,
+          r.email,
+          r.phone,
+          age,
+          AGE_BAND_LABELS[band],
+          genderLabel[normaliseGender(r.gender)],
+          r.group_name,
+          r.dietary_requirements,
+          r.medical_conditions,
+          r.accessibility_needs,
+          r.checked_in ? 'Yes' : 'No',
+        ]);
+      }
+      filename = `activity-teams-${new Date().toISOString().split('T')[0]}.csv`;
+
     } else {
       return createErrorResponse(errors.badRequest('Invalid export type', requestId));
     }

--- a/migrations/031_attendee_gender.sql
+++ b/migrations/031_attendee_gender.sql
@@ -1,0 +1,15 @@
+-- Optional gender on attendees, powering the Activity Teams balance heatmap
+-- (Male vs Female split per team) and the team CSV export.
+--
+-- Gender was never captured at registration, so this column is nullable and
+-- back-fills to NULL for every existing attendee. Admins set it per person in
+-- the attendee edit modal; anyone left NULL simply shows as "Unknown" in the
+-- balance views. Stored lower-case ('male' | 'female'); NULL/anything else is
+-- treated as unknown by the aggregation code.
+--
+-- Additive and safe to run on a live DB. The reading endpoints
+-- (activity-teams/breakdown, admin/export) and the attendee update handler all
+-- degrade gracefully if this column is missing, so code and migration can land
+-- in either order.
+
+ALTER TABLE attendees ADD COLUMN gender TEXT;

--- a/tests/activity-teams-breakdown.integration.test.ts
+++ b/tests/activity-teams-breakdown.integration.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { env } from 'cloudflare:test';
+import { onRequestGet as breakdown } from '../functions/api/admin/activity-teams/breakdown.js';
+import { onRequestGet as exportCsv } from '../functions/api/admin/export.js';
+import { setupDb, seedAttendee, methodRequest, adminBearer, ctx } from './helpers/db.js';
+
+// DOB helpers that stay in the intended age band regardless of when the suite
+// runs (ageFromDateOfBirth measures against "now").
+function yearsAgo(n: number): string {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+async function makeTeam(name: string, color: string, leaderId: number | null): Promise<number> {
+  const res = await env.DB.prepare(
+    'INSERT INTO activity_teams (name, description, color, leader_id) VALUES (?, ?, ?, ?)'
+  ).bind(name, `${name} desc`, color, leaderId).run();
+  return res.meta.last_row_id as number;
+}
+async function addMember(teamId: number, attendeeId: number): Promise<void> {
+  await env.DB.prepare('INSERT INTO activity_team_members (team_id, attendee_id) VALUES (?, ?)')
+    .bind(teamId, attendeeId).run();
+}
+
+describe('GET /api/admin/activity-teams/breakdown', () => {
+  let teamId: number;
+
+  beforeEach(async () => {
+    await setupDb();
+
+    // A demographically varied team.
+    const m1 = await seedAttendee({ ref: 'REF-A1', name: 'Adult Man', gender: 'male', date_of_birth: yearsAgo(40), checked_in: true, dietary_requirements: 'Vegetarian' });
+    const m2 = await seedAttendee({ ref: 'REF-A2', name: 'Adult Woman', gender: 'female', date_of_birth: yearsAgo(35), medical_conditions: 'Asthma' });
+    const m3 = await seedAttendee({ ref: 'REF-C1', name: 'Child Boy', gender: 'MALE', date_of_birth: yearsAgo(10), dietary_requirements: 'None' });
+    const m4 = await seedAttendee({ ref: 'REF-U5', name: 'Little One', gender: 'female', date_of_birth: yearsAgo(2), accessibility_needs: 'Step-free access' });
+    const m5 = await seedAttendee({ ref: 'REF-UK', name: 'Mystery Person' }); // no dob, no gender
+
+    teamId = await makeTeam('Kitchen Crew', '#10b981', m1);
+    for (const id of [m1, m2, m3, m4, m5]) await addMember(teamId, id);
+
+    // A second, empty team — must still appear with zero counts.
+    await makeTeam('Empty Squad', '#3b82f6', null);
+  });
+
+  async function callBreakdown() {
+    const res = await breakdown(ctx(methodRequest('GET', await adminBearer())));
+    return { status: res.status, json: await res.json() as any };
+  }
+
+  it('rejects unauthenticated requests', async () => {
+    const res = await breakdown(ctx(methodRequest('GET')));
+    expect(res.status).toBe(401);
+  });
+
+  it('aggregates age bands, gender, and flags per team', async () => {
+    const { status, json } = await callBreakdown();
+    expect(status).toBe(200);
+    expect(json.gender_available).toBe(true);
+    expect(json.team_count).toBe(2);
+
+    const team = json.teams.find((t: any) => t.id === teamId);
+    expect(team.member_count).toBe(5);
+    expect(team.leader_name).toBe('Adult Man');
+
+    // Age bands.
+    expect(team.age).toEqual({ adult: 2, child: 1, under5: 1, unknown: 1 });
+    // Gender (note 'MALE' normalises to male; the no-gender member is unknown).
+    expect(team.gender).toEqual({ male: 2, female: 2, unknown: 1 });
+    // Flags — dietary "None" must NOT count as a real dietary need.
+    expect(team.flags).toEqual({ dietary: 1, medical: 1, accessibility: 1, checked_in: 1 });
+
+    // Roster is present and typed.
+    expect(team.members).toHaveLength(5);
+    const boy = team.members.find((m: any) => m.ref_number === 'REF-C1');
+    expect(boy.age_band).toBe('child');
+    expect(boy.gender).toBe('male');
+    expect(boy.dietary).toBe(false); // "None"
+  });
+
+  it('includes empty teams with zero counts', async () => {
+    const { json } = await callBreakdown();
+    const empty = json.teams.find((t: any) => t.name === 'Empty Squad');
+    expect(empty.member_count).toBe(0);
+    expect(empty.members).toHaveLength(0);
+    expect(empty.age).toEqual({ adult: 0, child: 0, under5: 0, unknown: 0 });
+  });
+
+  it('totals sum across all teams', async () => {
+    const { json } = await callBreakdown();
+    expect(json.totals.member_count).toBe(5);
+    expect(json.totals.gender.male).toBe(2);
+    expect(json.totals.age.adult).toBe(2);
+  });
+
+  it('exports the teams roster as CSV', async () => {
+    const req = new Request('https://test.local/api/admin/export?type=activity-teams', {
+      method: 'GET',
+      headers: await adminBearer(),
+    });
+    const res = await exportCsv(ctx(req));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/csv');
+
+    const csv = await res.text();
+    const [header, ...lines] = csv.trim().split('\n');
+    expect(header).toContain('Team');
+    expect(header).toContain('Gender');
+    expect(header).toContain('Age Band');
+    // 5 membership rows (empty team contributes none).
+    expect(lines).toHaveLength(5);
+    expect(csv).toContain('Kitchen Crew');
+    expect(csv).toContain('Adult Man');
+    expect(csv).toContain('Vegetarian');
+  });
+});

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,5 +1,5 @@
 import { env } from 'cloudflare:test';
-import { hashPassword } from '../../functions/_shared/auth.js';
+import { hashPassword, generateAdminToken } from '../../functions/_shared/auth.js';
 import { createSchema } from './schema.js';
 
 // Fresh focused schema for each test (isolated storage gives each test its own
@@ -9,11 +9,14 @@ export async function setupDb() {
 }
 
 // Seed an attendee and return its id. `password` defaults to a valid one.
+// Optional demographic fields (date_of_birth, gender, dietary_requirements,
+// medical_conditions, accessibility_needs, checked_in) support the activity-team
+// balance tests; they default to null/0 so existing callers are unaffected.
 export async function seedAttendee(o) {
   const hash = await hashPassword(o.password ?? 'Password123');
   await env.DB.prepare(
-    `INSERT INTO attendees (name, first_name, last_name, ref_number, email, password_hash, payment_due, payment_status, must_reset_password, room_id, group_id)
-     VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)`
+    `INSERT INTO attendees (name, first_name, last_name, ref_number, email, password_hash, payment_due, payment_status, must_reset_password, room_id, group_id, date_of_birth, gender, dietary_requirements, medical_conditions, accessibility_needs, checked_in)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).bind(
     o.name ?? 'Test User',
     o.first_name ?? 'Test',
@@ -24,10 +27,22 @@ export async function seedAttendee(o) {
     o.payment_due ?? 0,
     o.must_reset ? 1 : 0,
     o.room_id ?? null,
-    o.group_id ?? null
+    o.group_id ?? null,
+    o.date_of_birth ?? null,
+    o.gender ?? null,
+    o.dietary_requirements ?? null,
+    o.medical_conditions ?? null,
+    o.accessibility_needs ?? null,
+    o.checked_in ? 1 : 0
   ).run();
   const row = await env.DB.prepare('SELECT id FROM attendees WHERE ref_number = ?').bind(o.ref).first();
   return row.id;
+}
+
+// Authorization header for an admin token (super_admin by default).
+export async function adminBearer(user = 'TestAdmin', role = 'super_admin') {
+  const token = await generateAdminToken(user, role, env.JWT_SECRET);
+  return { Authorization: `Bearer ${token}` };
 }
 
 // Build a JSON POST request for a Pages Function handler.

--- a/tests/helpers/schema.ts
+++ b/tests/helpers/schema.ts
@@ -25,12 +25,14 @@ const STATEMENTS = [
     tshirt_size TEXT,
     arrival_method TEXT,
     vehicle_registration TEXT,
+    gender TEXT,
     password_hash TEXT NOT NULL,
     payment_due REAL DEFAULT 0,
     payment_option TEXT DEFAULT 'full',
     payment_status TEXT DEFAULT 'pending',
     is_group_lead INTEGER DEFAULT 0,
     must_reset_password INTEGER DEFAULT 0,
+    checked_in INTEGER DEFAULT 0,
     room_id INTEGER,
     group_id INTEGER,
     last_login DATETIME,
@@ -105,6 +107,15 @@ const STATEMENTS = [
     user_type TEXT NOT NULL,
     user_id TEXT NOT NULL,
     login_time DATETIME DEFAULT CURRENT_TIMESTAMP
+  )`,
+  `CREATE TABLE audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    admin_user TEXT,
+    action TEXT,
+    entity_type TEXT,
+    entity_id INTEGER,
+    details TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
   )`,
 ];
 


### PR DESCRIPTION
## Summary

Adds admin-side depth to the Activity Teams menu: a clearer team/roster view, a per-team balance heatmap, and a CSV export.

### Clearer teams view
- Each team row expands into a member roster — every member shown as a chip with an age-band tag (Adult / Child / Under 5), a gender icon, and need/status icons (dietary, medical, accessibility, checked-in).
- A compact per-team balance bar (age + gender) sits in each row; leader is marked.

### Team Balance heatmap
- A teams × demographics matrix: **Age** (Adults / Children / Under 5 / unknown), **Gender** (Male / Female / unknown), **Needs & status** (dietary / medical / accessibility / checked-in).
- Each cell is shaded by that bucket's share of the team, so imbalances stand out at a glance. A totals row sums across all teams.

### CSV export
- "Export CSV" (`type=activity-teams` on `/api/admin/export`) → one row per team membership with the member's demographics.

## Data model
- New **optional** `attendees.gender` column (migration `031`), editable in the attendee edit modal. Gender was never collected, so all existing attendees read "Unknown" until set; the heatmap shows an inline note explaining this. Adults-vs-children works immediately from existing `date_of_birth` data.
- All gender reads/writes **degrade gracefully** if the column hasn't been migrated yet (defensive query + update retry), so code and migration can land in either order.

## Backend
- `_shared/team-demographics.ts` centralises age-band thresholds, gender normalisation, the defensive member query, and per-team aggregation — shared by the breakdown endpoint and the CSV export.
- `GET /api/admin/activity-teams/breakdown` returns per-team counts + rosters (static route, precedes the `[id]` dynamic route).

## Tests
- New `activity-teams-breakdown` integration test: aggregation, empty teams, totals, and the CSV export; plus admin-token / demographic-seed test helpers.
- **91 tests pass** (5 new), `tsc --noEmit` clean.

## ⚠️ Deploy note
Migration `031_attendee_gender.sql` must be applied to the production D1 for gender to persist and the Male/Female split to populate. Everything else (roster view, age heatmap, CSV export) works without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR)_