### PR TITLE
feat(admin): bulk gender-entry tool for attendees

### DIFF
--- a/frontend/public/css/components.css
+++ b/frontend/public/css/components.css
@@ -2723,3 +2723,72 @@ select.form-input option,
 .roster-ref { font-size: 0.68rem; color: var(--text-tertiary); margin-left: auto; }
 .roster-flag { font-size: 0.72rem; color: var(--text-secondary); }
 
+/* ===================== Bulk gender editor modal ===================== */
+.bulk-gender-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+.bulk-gender-toolbar .form-input { flex: 1; }
+.bulk-gender-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  cursor: pointer;
+}
+.bulk-gender-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.78rem;
+  color: var(--text-tertiary);
+  margin-bottom: 0.5rem;
+}
+.bulk-gender-pending {
+  color: #fbbf24;
+  font-weight: 600;
+}
+.bulk-gender-list {
+  max-height: 46vh;
+  overflow-y: auto;
+  border: 1px solid var(--glass-border, rgba(255,255,255,0.08));
+  border-radius: 8px;
+}
+.bulk-gender-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.45rem 0.65rem;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+}
+.bulk-gender-row:last-child { border-bottom: 0; }
+.bulk-gender-row.changed { background: rgba(251,191,36,0.08); }
+.bg-person { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+.bg-name { font-size: 0.85rem; font-weight: 600; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.bg-ref { font-size: 0.68rem; color: var(--text-tertiary); }
+.bg-segments {
+  display: inline-flex;
+  border: 1px solid var(--glass-border, rgba(255,255,255,0.14));
+  border-radius: 8px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.bg-seg {
+  padding: 0.3rem 0.6rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 0;
+  border-left: 1px solid var(--glass-border, rgba(255,255,255,0.14));
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.bg-seg:first-child { border-left: 0; }
+.bg-seg:hover { background: rgba(255,255,255,0.06); }
+.bg-seg.active { background: var(--primary-500); color: #fff; }
+

--- a/frontend/public/js/components/admin-dashboard.js
+++ b/frontend/public/js/components/admin-dashboard.js
@@ -1687,6 +1687,11 @@ const AdminDashboard = {
                 refreshBtn.disabled = false;
             });
         }
+        const bulkGenderBtn = document.getElementById('bulk-gender-btn');
+        if (bulkGenderBtn && !bulkGenderBtn._bound) {
+            bulkGenderBtn._bound = true;
+            bulkGenderBtn.addEventListener('click', () => this.showBulkGenderModal());
+        }
     },
 
     async exportTeamsCsv() {
@@ -1777,8 +1782,10 @@ const AdminDashboard = {
 
         const genderNote = !bd.gender_available || (bd.totals.gender.male + bd.totals.gender.female === 0)
             ? `<div class="team-balance-note"><i class="fas fa-circle-info"></i>
-                 Gender isn't recorded for these attendees yet. Set it on an attendee's profile (Attendees → edit)
-                 to populate the Male / Female split.</div>`
+                 <span>Gender isn't recorded for these attendees yet — the Male / Female split stays empty until it's set.</span>
+                 <button type="button" class="btn btn-sm btn-secondary" id="open-bulk-gender-from-note" style="margin-left:auto; white-space:nowrap;">
+                   <i class="fas fa-venus-mars"></i> Set genders
+                 </button></div>`
             : '';
 
         wrap.innerHTML = `
@@ -1803,6 +1810,166 @@ const AdminDashboard = {
               </table>
             </div>
             ${genderNote}`;
+
+        const noteBtn = document.getElementById('open-bulk-gender-from-note');
+        if (noteBtn) noteBtn.addEventListener('click', () => this.showBulkGenderModal());
+    },
+
+    // ---- Bulk gender editor ----
+    async showBulkGenderModal() {
+        let data;
+        try {
+            data = await API.get('/admin/attendees/bulk-gender');
+        } catch (e) {
+            Utils.showAlert('Failed to load attendees: ' + (e.message || e), 'error');
+            return;
+        }
+        this._bulkGenderList = data.attendees || [];
+        this._bulkGenderChanges = new Map(); // id -> 'male' | 'female' | null
+
+        const existing = document.getElementById('bulk-gender-modal');
+        if (existing) existing.remove();
+
+        const modal = document.createElement('div');
+        modal.className = 'modal-overlay';
+        modal.id = 'bulk-gender-modal';
+        modal.innerHTML = `
+            <div class="modal" style="max-width: 640px;">
+                <div class="modal-header">
+                    <h3 class="modal-title"><i class="fas fa-venus-mars"></i> Set Attendee Gender</h3>
+                    <button type="button" class="modal-close" id="bulk-gender-close"><i class="fas fa-times"></i></button>
+                </div>
+                <div class="modal-body">
+                    <div id="bulk-gender-alert" class="alert alert-error hidden"></div>
+                    <p style="font-size:0.82rem; color:var(--text-secondary); margin:0 0 0.75rem;">
+                        Set gender to populate the Male / Female balance. Changes are saved together when you click Save.
+                    </p>
+                    <div class="bulk-gender-toolbar">
+                        <input type="text" id="bulk-gender-search" class="form-input" placeholder="Search name or reference…">
+                        <label class="bulk-gender-filter"><input type="checkbox" id="bulk-gender-unset-only"> Unset only</label>
+                    </div>
+                    <div id="bulk-gender-summary" class="bulk-gender-summary"></div>
+                    <div id="bulk-gender-list" class="bulk-gender-list"></div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" id="bulk-gender-cancel">Cancel</button>
+                    <button type="button" class="btn btn-primary" id="bulk-gender-save">Save changes</button>
+                </div>
+            </div>`;
+        document.body.appendChild(modal);
+
+        const rerender = () => {
+            const filter = (document.getElementById('bulk-gender-search')?.value || '').trim().toLowerCase();
+            const unsetOnly = !!document.getElementById('bulk-gender-unset-only')?.checked;
+            this._renderBulkGenderList(filter, unsetOnly);
+        };
+
+        document.getElementById('bulk-gender-close').addEventListener('click', () => this.hideBulkGenderModal());
+        document.getElementById('bulk-gender-cancel').addEventListener('click', () => this.hideBulkGenderModal());
+        modal.addEventListener('click', (e) => { if (e.target === modal) this.hideBulkGenderModal(); });
+        document.getElementById('bulk-gender-search').addEventListener('input', rerender);
+        document.getElementById('bulk-gender-unset-only').addEventListener('change', rerender);
+        document.getElementById('bulk-gender-save').addEventListener('click', () => this._saveBulkGender());
+
+        // Delegated segment clicks.
+        document.getElementById('bulk-gender-list').addEventListener('click', (e) => {
+            const btn = e.target.closest('.bg-seg');
+            if (!btn) return;
+            const id = Number(btn.dataset.id);
+            const val = btn.dataset.val ? btn.dataset.val : null;
+            const original = this._currentGenderOf(id);
+            if (val === original) this._bulkGenderChanges.delete(id);
+            else this._bulkGenderChanges.set(id, val);
+            const row = btn.closest('.bulk-gender-row');
+            row.querySelectorAll('.bg-seg').forEach(b => b.classList.toggle('active', (b.dataset.val ? b.dataset.val : null) === val));
+            this._updateBulkGenderSummary();
+        });
+
+        this._renderBulkGenderList();
+        this._updateBulkGenderSummary();
+        setTimeout(() => document.getElementById('bulk-gender-search')?.focus(), 100);
+    },
+
+    _currentGenderOf(id) {
+        const a = this._bulkGenderList.find(x => x.id === id);
+        const g = a && typeof a.gender === 'string' ? a.gender.toLowerCase() : null;
+        return g === 'male' || g === 'female' ? g : null;
+    },
+    _effectiveGenderOf(a) {
+        if (this._bulkGenderChanges.has(a.id)) return this._bulkGenderChanges.get(a.id);
+        return this._currentGenderOf(a.id);
+    },
+
+    _renderBulkGenderList(filter = '', unsetOnly = false) {
+        const container = document.getElementById('bulk-gender-list');
+        if (!container) return;
+        let rows = this._bulkGenderList;
+        if (filter) rows = rows.filter(a =>
+            a.name.toLowerCase().includes(filter) || (a.ref_number || '').toLowerCase().includes(filter));
+        if (unsetOnly) rows = rows.filter(a => this._effectiveGenderOf(a) === null);
+
+        if (rows.length === 0) {
+            container.innerHTML = `<div style="padding:1rem; text-align:center; color:var(--text-tertiary); font-size:0.85rem;">No attendees match.</div>`;
+            return;
+        }
+
+        container.innerHTML = rows.map(a => {
+            const g = this._effectiveGenderOf(a);
+            const changed = this._bulkGenderChanges.has(a.id);
+            const seg = (val, label, icon) => {
+                const active = (val ? val : null) === g ? ' active' : '';
+                return `<button type="button" class="bg-seg${active}" data-id="${a.id}" data-val="${val}">${icon}${label}</button>`;
+            };
+            return `
+                <div class="bulk-gender-row${changed ? ' changed' : ''}">
+                    <div class="bg-person">
+                        <span class="bg-name">${Utils.escapeHtml(a.name)}</span>
+                        <span class="bg-ref">${Utils.escapeHtml(a.ref_number || '')}${a.group_name ? ' · ' + Utils.escapeHtml(a.group_name) : ''}</span>
+                    </div>
+                    <div class="bg-segments">
+                        ${seg('', 'Unknown', '')}
+                        ${seg('male', 'Male', '<i class="fas fa-mars"></i> ')}
+                        ${seg('female', 'Female', '<i class="fas fa-venus"></i> ')}
+                    </div>
+                </div>`;
+        }).join('');
+    },
+
+    _updateBulkGenderSummary() {
+        const el = document.getElementById('bulk-gender-summary');
+        if (!el) return;
+        const total = this._bulkGenderList.length;
+        let set = 0;
+        this._bulkGenderList.forEach(a => { if (this._effectiveGenderOf(a) !== null) set++; });
+        const pending = this._bulkGenderChanges.size;
+        el.innerHTML = `<span>${set} of ${total} set</span>
+            ${pending ? `<span class="bulk-gender-pending">${pending} unsaved change${pending === 1 ? '' : 's'}</span>` : ''}`;
+        const saveBtn = document.getElementById('bulk-gender-save');
+        if (saveBtn) saveBtn.textContent = pending ? `Save ${pending} change${pending === 1 ? '' : 's'}` : 'Save changes';
+    },
+
+    async _saveBulkGender() {
+        const updates = Array.from(this._bulkGenderChanges.entries()).map(([id, gender]) => ({ id, gender }));
+        if (updates.length === 0) { this.hideBulkGenderModal(); return; }
+        const btn = document.getElementById('bulk-gender-save');
+        const alert = document.getElementById('bulk-gender-alert');
+        try {
+            if (btn) { btn.disabled = true; btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving…'; }
+            const res = await API.post('/admin/attendees/bulk-gender', { updates });
+            this.hideBulkGenderModal();
+            Utils.showAlert(`Gender updated for ${res.updated} attendee${res.updated === 1 ? '' : 's'}`, 'success');
+            // Refresh the balance heatmap + roster chips with the new data.
+            await this.loadTeamBreakdown();
+            this.updateActivityTeamsDisplay();
+        } catch (e) {
+            if (alert) { alert.className = 'alert alert-error'; alert.textContent = e.message || 'Save failed'; alert.classList.remove('hidden'); }
+            if (btn) { btn.disabled = false; this._updateBulkGenderSummary(); }
+        }
+    },
+
+    hideBulkGenderModal() {
+        const modal = document.getElementById('bulk-gender-modal');
+        if (modal) modal.remove();
     },
 
     updateActivityTeamsDisplay() {

--- a/frontend/public/templates/admin-dashboard.html
+++ b/frontend/public/templates/admin-dashboard.html
@@ -650,6 +650,9 @@
                     <button class="btn btn-sm btn-ghost" id="refresh-team-balance-btn" title="Refresh balance">
                         <i class="fas fa-sync-alt"></i>
                     </button>
+                    <button class="btn btn-sm btn-secondary" id="bulk-gender-btn">
+                        <i class="fas fa-venus-mars"></i> Set Genders
+                    </button>
                     <button class="btn btn-sm btn-secondary" id="export-teams-csv-btn">
                         <i class="fas fa-file-csv"></i> Export CSV
                     </button>

--- a/functions/api/admin/attendees/bulk-gender.ts
+++ b/functions/api/admin/attendees/bulk-gender.ts
@@ -1,0 +1,125 @@
+// Bulk gender entry for attendees — backs the admin "Set Attendee Gender"
+// modal that populates the Activity Teams balance heatmap without editing
+// people one at a time.
+//
+//   GET  /api/admin/attendees/bulk-gender  -> every active attendee + current gender
+//   POST /api/admin/attendees/bulk-gender  -> { updates: [{ id, gender }] } applied in one batch
+//
+// Static route file — precedes the sibling [id].ts dynamic route for this
+// literal path. Both verbs degrade gracefully if the optional `gender` column
+// (migration 031) hasn't been applied yet.
+
+import type { PagesContext } from '../../../_shared/types.js';
+import { createResponse, checkAdminAuth, handleCORS } from '../../../_shared/auth.js';
+import { errors, createErrorResponse, generateRequestId, handleError } from '../../../_shared/errors.js';
+
+const MAX_UPDATES = 5000;
+
+function normaliseGender(input: unknown): 'male' | 'female' | null {
+  if (typeof input !== 'string') return null;
+  const v = input.trim().toLowerCase();
+  return v === 'male' || v === 'female' ? v : null;
+}
+
+export async function onRequestOptions(): Promise<Response> {
+  return handleCORS();
+}
+
+// List active attendees with their current gender for the bulk editor.
+export async function onRequestGet(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+
+  try {
+    const admin = await checkAdminAuth(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) return createErrorResponse(errors.unauthorized('Invalid or expired token', requestId));
+
+    const select = (genderExpr: string) => `
+      SELECT a.id, a.ref_number, a.name, ${genderExpr} AS gender, g.name AS group_name
+      FROM attendees a
+      LEFT JOIN groups g ON a.group_id = g.id
+      WHERE a.is_archived = 0 OR a.is_archived IS NULL
+      ORDER BY a.name
+    `;
+
+    let genderAvailable = true;
+    let results: Record<string, unknown>[];
+    try {
+      ({ results } = await context.env.DB.prepare(select('a.gender')).all() as { results: Record<string, unknown>[] });
+    } catch (err) {
+      if (/no such column|gender/i.test(String((err as Error)?.message))) {
+        genderAvailable = false;
+        ({ results } = await context.env.DB.prepare(select('NULL')).all() as { results: Record<string, unknown>[] });
+      } else {
+        throw err;
+      }
+    }
+
+    const attendees = results.map(r => ({
+      id: r.id as number,
+      ref_number: r.ref_number as string,
+      name: r.name as string,
+      gender: normaliseGender(r.gender),
+      group_name: (r.group_name as string | null) ?? null,
+    }));
+
+    return createResponse({ attendees, gender_available: genderAvailable, total: attendees.length });
+
+  } catch (error) {
+    console.error(`[${requestId}] bulk-gender GET error:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}
+
+// Apply a batch of { id, gender } updates. Unknown/invalid gender clears the
+// field (stores NULL). Returns how many rows were written.
+export async function onRequestPost(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+
+  try {
+    const admin = await checkAdminAuth(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) return createErrorResponse(errors.unauthorized('Invalid or expired token', requestId));
+
+    const body = await context.request.json() as { updates?: Array<{ id?: unknown; gender?: unknown }> };
+    const updates = Array.isArray(body?.updates) ? body.updates : null;
+    if (!updates) return createErrorResponse(errors.badRequest('updates array is required', requestId));
+    if (updates.length === 0) return createResponse({ updated: 0 });
+    if (updates.length > MAX_UPDATES) {
+      return createErrorResponse(errors.badRequest(`Too many updates (max ${MAX_UPDATES})`, requestId));
+    }
+
+    const stmt = context.env.DB.prepare('UPDATE attendees SET gender = ? WHERE id = ?');
+    const batch = [];
+    for (const u of updates) {
+      const id = Number(u?.id);
+      if (!Number.isInteger(id) || id <= 0) {
+        return createErrorResponse(errors.badRequest('Each update needs a valid attendee id', requestId));
+      }
+      batch.push(stmt.bind(normaliseGender(u?.gender), id));
+    }
+
+    try {
+      await context.env.DB.batch(batch);
+    } catch (err) {
+      if (/no such column|gender/i.test(String((err as Error)?.message))) {
+        return createErrorResponse(errors.badRequest('Gender column not available yet — apply migration 031.', requestId));
+      }
+      throw err;
+    }
+
+    // Best-effort audit trail — this is a bulk PII write.
+    try {
+      await context.env.DB.prepare(
+        `INSERT INTO audit_log (admin_user, action, entity_type, entity_id, details)
+         VALUES (?, 'bulk_gender', 'attendee', 0, ?)`
+      ).bind(admin.user, JSON.stringify({ count: batch.length })).run();
+    } catch (err) {
+      console.warn(`[${requestId}] audit_log write failed`, err);
+    }
+
+    return createResponse({ updated: batch.length });
+
+  } catch (error) {
+    console.error(`[${requestId}] bulk-gender POST error:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}

--- a/tests/bulk-gender.integration.test.ts
+++ b/tests/bulk-gender.integration.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { env } from 'cloudflare:test';
+import { onRequestGet as listGenders, onRequestPost as applyGenders } from '../functions/api/admin/attendees/bulk-gender.js';
+import { setupDb, seedAttendee, jsonRequest, methodRequest, adminBearer, ctx } from './helpers/db.js';
+
+describe('bulk-gender endpoints', () => {
+  let a1: number, a2: number, a3: number;
+
+  beforeEach(async () => {
+    await setupDb();
+    a1 = await seedAttendee({ ref: 'REF-1', name: 'Alice' });                    // unset
+    a2 = await seedAttendee({ ref: 'REF-2', name: 'Bob', gender: 'male' });       // preset male
+    a3 = await seedAttendee({ ref: 'REF-3', name: 'Carol' });                     // unset
+  });
+
+  async function listCall() {
+    const res = await listGenders(ctx(methodRequest('GET', await adminBearer())));
+    return { status: res.status, json: await res.json() as any };
+  }
+  async function applyCall(body: any) {
+    const res = await applyGenders(ctx(jsonRequest(body, await adminBearer())));
+    return { status: res.status, json: await res.json() as any };
+  }
+
+  it('requires admin auth for both verbs', async () => {
+    const g = await listGenders(ctx(methodRequest('GET')));
+    expect(g.status).toBe(401);
+    const p = await applyGenders(ctx(jsonRequest({ updates: [] })));
+    expect(p.status).toBe(401);
+  });
+
+  it('lists attendees with their current gender', async () => {
+    const { status, json } = await listCall();
+    expect(status).toBe(200);
+    expect(json.gender_available).toBe(true);
+    expect(json.total).toBe(3);
+    const bob = json.attendees.find((a: any) => a.ref_number === 'REF-2');
+    expect(bob.gender).toBe('male');
+    const alice = json.attendees.find((a: any) => a.ref_number === 'REF-1');
+    expect(alice.gender).toBeNull();
+  });
+
+  it('applies a batch of gender updates', async () => {
+    const { status, json } = await applyCall({
+      updates: [
+        { id: a1, gender: 'female' },
+        { id: a2, gender: 'male' },
+        { id: a3, gender: 'Female' }, // case-normalised
+      ],
+    });
+    expect(status).toBe(200);
+    expect(json.updated).toBe(3);
+
+    const rows = await env.DB.prepare('SELECT ref_number, gender FROM attendees ORDER BY ref_number').all();
+    const map = Object.fromEntries((rows.results as any[]).map(r => [r.ref_number, r.gender]));
+    expect(map['REF-1']).toBe('female');
+    expect(map['REF-2']).toBe('male');
+    expect(map['REF-3']).toBe('female');
+  });
+
+  it('clears gender when given an unknown/blank value', async () => {
+    await applyCall({ updates: [{ id: a2, gender: '' }, { id: a1, gender: 'nonsense' }] });
+    const bob = await env.DB.prepare('SELECT gender FROM attendees WHERE id = ?').bind(a2).first();
+    expect(bob!.gender).toBeNull();
+  });
+
+  it('rejects a payload without an updates array', async () => {
+    const { status } = await applyCall({ nope: true });
+    expect(status).toBe(400);
+  });
+
+  it('rejects updates with an invalid id', async () => {
+    const { status } = await applyCall({ updates: [{ id: 'abc', gender: 'male' }] });
+    expect(status).toBe(400);
+  });
+
+  it('treats an empty updates array as a no-op', async () => {
+    const { status, json } = await applyCall({ updates: [] });
+    expect(status).toBe(200);
+    expect(json.updated).toBe(0);
+  });
+});

--- a/tests/helpers/schema.ts
+++ b/tests/helpers/schema.ts
@@ -33,6 +33,7 @@ const STATEMENTS = [
     is_group_lead INTEGER DEFAULT 0,
     must_reset_password INTEGER DEFAULT 0,
     checked_in INTEGER DEFAULT 0,
+    is_archived INTEGER DEFAULT 0,
     room_id INTEGER,
     group_id INTEGER,
     last_login DATETIME,


### PR DESCRIPTION
## Summary

Follows up the Activity Teams balance heatmap with a fast way to fill in gender for the whole retreat, instead of editing attendees one at a time.

## What's added

**Backend — `GET`/`POST /api/admin/attendees/bulk-gender`**
- `GET` lists every active attendee with their current gender (+ group), for the editor.
- `POST` applies a batch of `{ id, gender }` updates in a single D1 batch. Gender is normalised to `male`/`female`; anything else (including blank) clears the field.
- Both verbs are admin-only and degrade gracefully if the `gender` column isn't migrated yet.

**Frontend — "Set Genders" modal**
- Opened from the **Team Balance** panel header and from the gender-unknown note.
- Searchable list; each attendee has an **Unknown / Male / Female** segmented control.
- "Unset only" filter, a running "X of N set · Y unsaved changes" summary, and it saves only the rows you changed.
- On save it refreshes the balance heatmap so the Male/Female split updates in place.

## Tests
- New `bulk-gender` integration test: list, batch apply, case normalisation, clear-on-unknown, validation (bad id / missing array), and empty no-op.
- Added `is_archived` to the test attendees schema so the list query matches production.
- **98 tests pass** (7 new), `tsc --noEmit` clean.

## Note
The `gender` column (migration `031`) is already applied to production, so this works end-to-end on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR)_