### PR TITLE
fix(mobile): resolve HIGH + MED responsiveness issues

### DIFF
--- a/frontend/public/allergy.html
+++ b/frontend/public/allergy.html
@@ -25,12 +25,13 @@
         label { display: block; font-weight: 600; color: #374151; margin-bottom: 0.5rem; font-size: 0.9rem; }
         input[type="text"], input[type="email"], textarea, select {
             width: 100%; padding: 0.65rem 0.85rem; border: 1px solid #d1d5db; border-radius: 8px;
-            font-family: inherit; font-size: 0.95rem; background: #fff; color: #111827;
+            /* 16px keeps iOS Safari from zooming in on focus. */
+            font-family: inherit; font-size: 16px; background: #fff; color: #111827;
         }
         input:focus, textarea:focus, select:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 3px rgba(102,126,234,0.15); }
         textarea { resize: vertical; min-height: 80px; }
         .radio-group, .checkbox-group { display: flex; gap: 1rem; flex-wrap: wrap; }
-        .radio-group label, .checkbox-group label { font-weight: 500; display: inline-flex; gap: 0.4rem; cursor: pointer; align-items: center; }
+        .radio-group label, .checkbox-group label { font-weight: 500; display: inline-flex; gap: 0.4rem; cursor: pointer; align-items: center; min-height: 44px; padding: 0.25rem 0; }
         .help { color: #6b7280; font-size: 0.8rem; margin-top: 0.35rem; }
         .conditional { display: none; padding-left: 1rem; border-left: 3px solid var(--primary); margin-top: 1rem; }
         .conditional.shown { display: block; }

--- a/frontend/public/css/components.css
+++ b/frontend/public/css/components.css
@@ -597,7 +597,11 @@ select.form-input option,
   background: var(--bg-card);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-xl);
-  overflow: hidden;
+  /* Scroll wide tables horizontally instead of clipping their right-hand
+     columns on narrow screens (phones/tablets). The mobile card-view in
+     responsive.css is disabled for tables inside this container. */
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .table {
@@ -2637,7 +2641,7 @@ select.form-input option,
 /* ===================== Activity Teams — balance heatmap ===================== */
 .team-balance-wrap { padding: 0.25rem; }
 
-.heatmap-table { border-collapse: separate; border-spacing: 0; font-size: 0.8rem; }
+.heatmap-table { border-collapse: separate; border-spacing: 0; font-size: 0.8rem; min-width: 700px; }
 .heatmap-table th,
 .heatmap-table td { padding: 0.4rem 0.55rem; }
 .heatmap-table thead th {
@@ -2791,4 +2795,12 @@ select.form-input option,
 .bg-seg:first-child { border-left: 0; }
 .bg-seg:hover { background: rgba(255,255,255,0.06); }
 .bg-seg.active { background: var(--primary-500); color: #fff; }
+
+/* On narrow phones the fixed Unknown/Male/Female control squeezes the name;
+   stack it below the name and let the segments share the full width. */
+@media (max-width: 480px) {
+  .bulk-gender-row { flex-direction: column; align-items: stretch; gap: 0.4rem; }
+  .bulk-gender-row .bg-segments { width: 100%; }
+  .bulk-gender-row .bg-seg { flex: 1; }
+}
 

--- a/frontend/public/css/responsive.css
+++ b/frontend/public/css/responsive.css
@@ -437,6 +437,41 @@
     justify-content: center;
   }
 
+  /* The stacked "card view" above depends on data-label attributes the markup
+     never emits, so it renders unlabeled — and it destroys the multi-column
+     admin tables and the balance heatmap. Every data-dense table lives inside
+     a .table-container (which now scrolls horizontally), so restore those to
+     real, scrollable tables. Simple key/value tables elsewhere keep the card
+     view. */
+  .table-container .table { display: table; min-width: 640px; }
+  .table-container .table thead { display: table-header-group; }
+  .table-container .table tbody { display: table-row-group; }
+  .table-container .table tr {
+    display: table-row;
+    margin: 0;
+    padding: 0;
+    background: none;
+    border: 0;
+  }
+  .table-container .table th,
+  .table-container .table td {
+    display: table-cell;
+    width: auto;
+    text-align: left;
+    padding: var(--space-3);
+    border: none;
+    border-bottom: 1px solid var(--border-color);
+  }
+  .table-container .table td::before { content: none; }
+  .table-container .table td:last-child {
+    margin-top: 0;
+    padding-top: var(--space-3);
+    border-top: none;
+    justify-content: flex-start;
+  }
+  /* Heatmap is wider than a generic table — give it room so it scrolls. */
+  .table-container .heatmap-table { min-width: 700px; }
+
   .action-buttons {
     flex-direction: row;
     flex-wrap: wrap;
@@ -648,8 +683,34 @@
   /* Larger touch targets */
   .btn,
   .tab-btn,
-  .sidebar-link {
+  .sidebar-link,
+  .att-nav-link,
+  .menu-toggle,
+  .att-sidebar-toggle-btn,
+  .modal-close,
+  .btn-icon,
+  .password-toggle-light,
+  .password-toggle,
+  .sched-star,
+  .community-del,
+  .community-type-btn,
+  .bg-seg {
     min-height: 44px;
+  }
+
+  /* Icon-only / inline controls also need width and centering to reach 44px. */
+  .menu-toggle,
+  .att-sidebar-toggle-btn,
+  .modal-close,
+  .btn-icon,
+  .password-toggle-light,
+  .password-toggle,
+  .sched-star,
+  .community-del {
+    min-width: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
   }
 
   /* Remove hover effects that don't work well on touch */
@@ -780,4 +841,20 @@
    ============================================ */
 @media (prefers-color-scheme: light) {
   /* Add light mode overrides here if implementing light theme */
+}
+
+/* ============================================
+   iOS input zoom guard
+   ============================================ */
+/* Mobile Safari zooms the viewport in whenever a focused form control has a
+   font-size below 16px. Floor every text control at 16px on touch pointers so
+   focusing a field never yanks the layout around. Scoped to coarse pointers so
+   desktop density is untouched; !important so it also wins over the inline
+   font-sizes on JS-injected attendee fields. */
+@media (pointer: coarse) {
+  input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
 }

--- a/frontend/public/js/components/attendee-dashboard.js
+++ b/frontend/public/js/components/attendee-dashboard.js
@@ -635,7 +635,7 @@ const AttendeeDashboard = {
             `<a href="${href}" target="_blank" rel="noopener" style="display:flex; align-items:center; gap:0.6rem; font-size:0.88rem; color:var(--text-secondary); text-decoration:none; padding:0.55rem 0.65rem; border-radius:8px; background:rgba(255,255,255,0.03); border:1px solid rgba(255,255,255,0.06);"><i class="fas ${icon}" style="color:${color}; width:1.1rem; text-align:center;"></i> ${text}</a>`;
 
         container.innerHTML = `
-            <div style="display:grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap:1.25rem; align-items:start;">
+            <div style="display:grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr)); gap:1.25rem; align-items:start;">
                 <div class="data-table">
                     <div class="table-header"><h3 class="table-title"><i class="fas fa-map-location-dot"></i> Getting there</h3></div>
                     <div class="table-content" style="padding:1.25rem; display:grid; gap:1rem;">
@@ -838,7 +838,7 @@ const AttendeeDashboard = {
         // so contact info doesn't stretch across the full width on ultra-
         // wide screens — `auto-fill` plus a minmax floor at 320px gives
         // 1 column on mobile, 2 columns above ~720px, 3 above ~1080px.
-        container.innerHTML = `<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 0.85rem; padding: 1rem 1.25rem;">${
+        container.innerHTML = `<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 320px), 1fr)); gap: 0.85rem; padding: 1rem 1.25rem;">${
             res.members.map((m) => {
                 const leadTag = m.is_group_lead ? '<span class="badge badge-success" style="margin-left:0.4rem;"><i class="fas fa-crown"></i> Lead</span>' : '';
                 const selfTag = m.is_self ? '<span class="badge badge-secondary" style="margin-left:0.4rem;">You</span>' : '';
@@ -2730,7 +2730,7 @@ const AttendeeDashboard = {
 
         // Card grid so multiple teams sit side-by-side on wide screens
         // instead of stacking in a narrow column.
-        container.innerHTML = `<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 0.85rem;">${
+        container.innerHTML = `<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 280px), 1fr)); gap: 0.85rem;">${
             teams.map(team => {
               const color = team.color || '#8b5cf6';
               return `

--- a/frontend/public/register.html
+++ b/frontend/public/register.html
@@ -426,6 +426,8 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
+            flex-wrap: wrap;
+            gap: 0.5rem;
             margin-bottom: 1rem;
         }
 


### PR DESCRIPTION
## Summary

Implements the HIGH and MEDIUM findings from the mobile-responsiveness review. All changes target phones (~360–414px) and are scoped so desktop is unchanged.

## HIGH

**Admin tables were unusable on phones**
- `.table-container` now scrolls horizontally (was `overflow:hidden`, which clipped the right-hand columns of every wide admin table with no way to reach them).
- The ≤480px table "card view" relied on `data-label` attributes the markup never emits, so it rendered unlabeled **and** flattened the 13-column Team Balance heatmap into a meaningless number list. Since every data-dense table lives in a `.table-container`, those are restored to real, horizontally-scrollable tables (the heatmap's sticky team column now works too). Generic key/value tables keep the card view.

**Attendee grids forced whole-page horizontal scroll**
- Family / Resources / Activity-Teams grids used `minmax(320px|280px, 1fr)`, whose floor exceeds a narrow phone's content box. Changed to `minmax(min(100%, N), 1fr)` so they collapse to one column when they can't fit.

## MED

- **iOS zoom guard:** all text inputs/selects/textareas float to `16px` on coarse pointers — fixes the attendee inline forms (My Details, Transport, emergency contact, Family edit, community), admin filters, and the allergy form. Focusing a field no longer zooms the viewport.
- **44px touch targets** extended to the nav toggles, nav links, schedule star, community buttons, bulk-gender segments, modal close, icon buttons and password toggles (the base rule only covered `.btn/.tab-btn/.sidebar-link`).
- **Bulk-gender rows** stack vertically ≤480px so the name isn't squeezed by the Male/Female control.
- **register.html** member-header wraps; **allergy.html** inputs are 16px with 44px radio/checkbox labels.

## Not included (LOW / polish)
Fluid `clamp()` type, `.container`/`style.css` cascade cleanup, tiny-label bumps, unstyled announcement cards, etc. — deferred by request.

## Tests
No backend files changed; **98 tests pass**, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR)_