### PR TITLE
polish(mobile): LOW responsiveness items from the review

### DIFF
--- a/frontend/public/checkin/app.css
+++ b/frontend/public/checkin/app.css
@@ -128,8 +128,8 @@ body {
     background: transparent;
     border: none;
     color: var(--text-dim);
-    width: 38px;
-    height: 38px;
+    width: 44px;
+    height: 44px;
     cursor: pointer;
     font-size: 0.95rem;
 }

--- a/frontend/public/css/base.css
+++ b/frontend/public/css/base.css
@@ -62,8 +62,9 @@ h1, h2, h3, h4, h5, h6 {
   margin: 0;
 }
 
-h1 { font-size: var(--text-4xl); }
-h2 { font-size: var(--text-3xl); }
+/* Fluid headings so a raw h1/h2 scales down on phones instead of only wrapping. */
+h1 { font-size: clamp(1.65rem, 1.1rem + 2.6vw, var(--text-4xl)); }
+h2 { font-size: clamp(1.45rem, 1.05rem + 1.9vw, var(--text-3xl)); }
 h3 { font-size: var(--text-2xl); }
 h4 { font-size: var(--text-xl); }
 h5 { font-size: var(--text-lg); }
@@ -297,10 +298,10 @@ a:hover {
   }
 }
 
-/* Container */
+/* Container — the effective max-width is defined once in layout.css
+   (.container / .container-lg); this rule only owns the responsive padding. */
 .container {
   width: 100%;
-  max-width: var(--container-xl);
   margin: 0 auto;
   padding: 0 var(--space-4);
 }

--- a/frontend/public/css/components.css
+++ b/frontend/public/css/components.css
@@ -1874,7 +1874,8 @@ select.form-input option,
   font-weight: var(--font-medium);
   color: #6b7280;
   text-decoration: none;
-  padding: var(--space-2) var(--space-3);
+  padding: var(--space-3);
+  min-height: 44px;
   border-radius: 8px;
   transition: color var(--transition-fast), background var(--transition-fast);
 }
@@ -2481,8 +2482,10 @@ select.form-input option,
   .attendee-sidebar.open::after {
     content: '';
     position: fixed;
-    top: 0; left: 260px;
-    width: 100vw; height: 100vh;
+    /* right:0 instead of width:100vw so the backdrop never extends past the
+       viewport edge (which nudged horizontal overflow while the drawer is open). */
+    top: 0; left: 260px; right: 0;
+    height: 100vh;
     background: rgba(0, 0, 0, 0.4);
     z-index: -1;
   }
@@ -2802,5 +2805,61 @@ select.form-input option,
   .bulk-gender-row { flex-direction: column; align-items: stretch; gap: 0.4rem; }
   .bulk-gender-row .bg-segments { width: 100%; }
   .bulk-gender-row .bg-seg { flex: 1; }
+}
+
+/* ===================== Attendee announcement cards ===================== */
+/* These were rendered with no CSS and fell back to bare block flow. Give them
+   a proper card treatment with a priority-coded left accent. */
+.announcement-card {
+  background: var(--bg-card, rgba(255,255,255,0.03));
+  border: 1px solid var(--glass-border, rgba(255,255,255,0.08));
+  border-left: 3px solid var(--primary-500);
+  border-radius: 12px;
+  padding: 1rem 1.15rem;
+  margin-bottom: 0.85rem;
+}
+.announcement-card.priority-urgent { border-left-color: var(--error, #ef4444); }
+.announcement-card.priority-high   { border-left-color: var(--warning, #f59e0b); }
+.announcement-card.priority-normal { border-left-color: var(--primary-500); }
+.announcement-card.priority-low    { border-left-color: var(--neutral-500, #64748b); }
+.announcement-card[data-new="true"] { box-shadow: 0 0 0 1px rgba(139,92,246,0.35); }
+
+.announcement-header { margin-bottom: 0.5rem; }
+.announcement-title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+.announcement-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+.announcement-badges { display: inline-flex; gap: 0.35rem; flex-wrap: wrap; }
+.announcement-meta { margin-top: 0.35rem; color: var(--text-tertiary); font-size: 0.75rem; }
+.announcement-meta i { margin-right: 0.2rem; }
+.announcement-content { color: var(--text-secondary); font-size: 0.9rem; line-height: 1.55; }
+.announcement-content p { margin: 0 0 0.5rem; color: inherit; }
+.announcement-footer {
+  margin-top: 0.6rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--glass-border, rgba(255,255,255,0.06));
+}
+.new-badge {
+  background: var(--primary-500);
+  color: #fff;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 0.1rem 0.35rem;
+  border-radius: 999px;
+  vertical-align: middle;
 }
 

--- a/frontend/public/css/responsive.css
+++ b/frontend/public/css/responsive.css
@@ -252,7 +252,9 @@
   .modal {
     margin: var(--space-4);
     max-height: calc(100vh - var(--space-8));
-    max-width: calc(100vw - var(--space-8));
+    /* 100% (not 100vw) so the scrollbar width can't push the modal wider than
+       the viewport. */
+    max-width: calc(100% - var(--space-8));
     border-radius: var(--radius-xl);
   }
 
@@ -856,5 +858,18 @@
   textarea,
   select {
     font-size: 16px !important;
+  }
+}
+
+/* ============================================
+   Grid utilities — collapse on phones
+   ============================================ */
+/* .grid-cols-2/3/4 have no intrinsic responsive behaviour; stack them so they
+   never force multi-column overflow if used on small screens. */
+@media (max-width: 480px) {
+  .grid-cols-2,
+  .grid-cols-3,
+  .grid-cols-4 {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/public/css/style.css
+++ b/frontend/public/css/style.css
@@ -1,7 +1,0 @@
-* { box-sizing: border-box; margin: 0; padding: 0; }
-body { font-family: sans-serif; line-height: 1.4; padding: 1rem; }
-.container { max-width: 400px; margin: auto; }
-form { display: flex; flex-direction: column; gap: 0.5rem; }
-button { padding: 0.5rem; cursor: pointer; }
-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }

--- a/frontend/public/faq.html
+++ b/frontend/public/faq.html
@@ -86,10 +86,15 @@
             position: absolute;
             top: 1.5rem;
             left: 1.5rem;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 44px;
+            min-height: 44px;
             background: rgba(255, 255, 255, 0.2);
             border: 1px solid rgba(255, 255, 255, 0.3);
             color: white;
-            padding: 0.75rem;
+            padding: 0.5rem 0.75rem;
             border-radius: var(--border-radius);
             cursor: pointer;
             transition: var(--transition);

--- a/frontend/public/js/components/attendee-dashboard.js
+++ b/frontend/public/js/components/attendee-dashboard.js
@@ -861,7 +861,7 @@ const AttendeeDashboard = {
                             <div>${dueLine}</div>
                         </div>
                         <div style="font-size: 0.78rem; color: var(--text-secondary); display: flex; flex-direction: column; gap: 0.3rem;">
-                            ${m.email ? `<div style="overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"><i class="fas fa-envelope" style="width:1rem; color: var(--text-tertiary);"></i> ${this._escape(m.email)}</div>` : ''}
+                            ${m.email ? `<div style="word-break: break-word;"><i class="fas fa-envelope" style="width:1rem; color: var(--text-tertiary);"></i> ${this._escape(m.email)}</div>` : ''}
                             ${m.phone ? `<div><i class="fas fa-phone" style="width:1rem; color: var(--text-tertiary);"></i> ${this._escape(m.phone)}</div>` : ''}
                             ${m.emergency_contact ? `<div><i class="fas fa-life-ring" style="width:1rem; color: var(--text-tertiary);"></i> ${this._escape(m.emergency_contact)}</div>` : ''}
                             ${m.dietary_requirements ? `<div><i class="fas fa-utensils" style="width:1rem; color: var(--text-tertiary);"></i> ${this._escape(m.dietary_requirements)}</div>` : ''}
@@ -2631,7 +2631,7 @@ const AttendeeDashboard = {
             const unit = (val, label) => `
                 <div style="text-align: center;">
                     <div style="font-size: 1.75rem; font-weight: 700; color: #fff; line-height: 1;">${val}</div>
-                    <div style="font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-tertiary); margin-top: 0.2rem;">${label}</div>
+                    <div style="font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-tertiary); margin-top: 0.2rem;">${label}</div>
                 </div>`;
             display.innerHTML = unit(days, 'Days') + unit(hours, 'Hours') + unit(mins, 'Mins') + unit(secs, 'Secs');
         };

--- a/frontend/public/offline.html
+++ b/frontend/public/offline.html
@@ -38,8 +38,9 @@
             color: #fff;
             border: none;
             border-radius: 10px;
-            padding: 0.75rem 1.5rem;
-            font-size: 0.95rem;
+            padding: 0.85rem 1.5rem;
+            min-height: 44px;
+            font-size: 1rem;
             font-weight: 600;
             cursor: pointer;
         }

--- a/frontend/public/privacy.html
+++ b/frontend/public/privacy.html
@@ -29,7 +29,7 @@
         h1 { font-size: 1.6rem; color: #fff; margin-bottom: 0.25rem; }
         .sub { color: #9999bb; font-size: 0.9rem; margin-bottom: 1.5rem; }
         h2 { font-size: 1.05rem; color: #c4b5fd; margin: 1.6rem 0 0.5rem; }
-        p, li { color: #c5c5e0; font-size: 0.92rem; }
+        p, li { color: #c5c5e0; font-size: 1rem; line-height: 1.6; }
         ul { margin: 0.4rem 0 0 1.2rem; }
         li { margin-bottom: 0.35rem; }
         a { color: #a78bfa; }

--- a/frontend/public/register.html
+++ b/frontend/public/register.html
@@ -306,6 +306,7 @@
             display: inline-flex;
             align-items: center;
             gap: 0.5rem;
+            min-height: 44px;
             color: var(--primary);
             text-decoration: none;
             margin-top: 2rem;
@@ -314,6 +315,13 @@
 
         .back-link:hover {
             text-decoration: underline;
+        }
+
+        /* Reclaim horizontal space on small phones — the stacked body + card
+           padding leaves member cards very narrow otherwise. */
+        @media (max-width: 600px) {
+            body { padding: 1rem; }
+            .form-card { padding: 1.25rem; }
         }
 
         .loading-spinner {


### PR DESCRIPTION
## Summary

The remaining LOW/polish items from the mobile-responsiveness review. Frontend/CSS-only.

### Foundation & type
- **Fluid `h1`/`h2`** via `clamp()` so raw headings scale down on phones instead of only wrapping.
- Removed the **dead, unlinked `style.css`** and the redundant `.container` `max-width` in `base.css` (layout.css is now the single source of truth) — no runtime change, just removes the 3-way `.container` conflict the review flagged.
- Modal `max-width` uses `100%` instead of `100vw` (scrollbar-safe).
- `.grid-cols-2/3/4` utilities collapse to one column ≤480px.

### Attendee dashboard
- **Styled the announcement cards** (previously no CSS at all → bare block flow): priority-coded left accent, badge row, meta line, NEW pill.
- Family-member **email wraps** instead of truncating out of view.
- Countdown unit labels bumped off ~9.6px.
- Sidebar backdrop uses `right:0` instead of `width:100vw` (no overflow while the drawer is open).

### Standalone pages / touch targets
- `.admin-access-link`, the faq back button, offline "Try again", register back-link, and the check-in password toggle raised to ≥44px.
- privacy body copy `0.92rem` → `1rem`; register reduces body/card padding on small phones.

## Tests
Frontend-only; **98 tests pass**, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR)_