### PR TITLE
fix(pwa): only show install chip inside the app, not over the login form

### DIFF
--- a/frontend/public/css/components.css
+++ b/frontend/public/css/components.css
@@ -2500,7 +2500,7 @@ select.form-input option,
 .pwa-install-chip {
   position: fixed;
   left: 50%;
-  bottom: 1.1rem;
+  bottom: calc(1.1rem + env(safe-area-inset-bottom, 0px));
   transform: translateX(-50%);
   z-index: var(--z-toast, 700);
   display: inline-flex;

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -160,11 +160,31 @@
             return chip;
         }
 
+        // Only surface the install chip once the user is actually inside the
+        // app (an auth token exists). The chip is fixed to the bottom-centre of
+        // the screen, so on the login / registration views it would float over
+        // the form inputs and the Sign In button. Poll until authed, then show
+        // it once.
+        function isInsideApp() {
+            try { return !!(localStorage.getItem('attendeeToken') || localStorage.getItem('adminToken')); }
+            catch (_) { return false; }
+        }
+        function showChipWhenReady(label, onClick) {
+            try { if (localStorage.getItem(DISMISS_KEY)) return; } catch (_) {}
+            if (document.getElementById('pwa-install-chip')) return;
+            if (isInsideApp()) { makeChip(label, onClick); return; }
+            const timer = setInterval(() => {
+                let dismissed = false;
+                try { dismissed = !!localStorage.getItem(DISMISS_KEY); } catch (_) {}
+                if (dismissed || document.getElementById('pwa-install-chip')) { clearInterval(timer); return; }
+                if (isInsideApp()) { clearInterval(timer); makeChip(label, onClick); }
+            }, 1500);
+        }
+
         window.addEventListener('beforeinstallprompt', (e) => {
             e.preventDefault();
             deferredPrompt = e;
-            try { if (localStorage.getItem(DISMISS_KEY)) return; } catch (_) {}
-            makeChip('Install app', async () => {
+            showChipWhenReady('Install app', async () => {
                 if (!deferredPrompt) return;
                 deferredPrompt.prompt();
                 await deferredPrompt.userChoice;
@@ -189,7 +209,7 @@
             try { dismissed = !!localStorage.getItem(DISMISS_KEY); } catch (_) {}
             if (!dismissed) {
                 window.addEventListener('load', () => setTimeout(() => {
-                    makeChip('Add to Home Screen', () => {
+                    showChipWhenReady('Add to Home Screen', () => {
                         alert('To install: tap the Share button, then choose "Add to Home Screen".');
                     });
                 }, 2500));


### PR DESCRIPTION
## Problem

The floating **"Install app" / "Add to Home Screen"** chip is `position: fixed; bottom: 1.1rem` — so on the login and registration views it floated **on top of the form**, covering the password field and the Sign In button (visible in a mobile screenshot).

## Fix

Both triggers (Android `beforeinstallprompt` and the iOS Safari fallback) now route through a small gate that shows the chip **only once an auth token exists** — i.e. once the user is inside the app, where the chip was designed to float. If the user isn't signed in yet, it polls and appears right after login. Also offset the chip by `env(safe-area-inset-bottom)` so it clears the iPhone home indicator.

## Verification

Headless iPhone viewport (Playwright):
- Login screen, not signed in → chip **absent** ✓
- Token present (inside app) → chip **appears** ✓

Frontend-only (`index.html` + one CSS line). 98 tests pass, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR)_