### PR TITLE
fix(auth): never reset password on profile edit + self-service recovery

### DIFF
--- a/frontend/public/js/components/attendee-management.js
+++ b/frontend/public/js/components/attendee-management.js
@@ -72,18 +72,24 @@ const AttendeeManagement = {
             document.getElementById('attendee-room').value = editData.room_id || '';
             document.getElementById('attendee-group').value = editData.group_id || '';
 
-            // Password not required when editing
+            // Editing: the profile form must NOT carry a password. Hide the
+            // password input entirely (so nothing — including browser autofill —
+            // can ride along and silently reset it) and offer an explicit
+            // "Reset Password" action instead.
             const passwordInput = document.getElementById('attendee-password');
             passwordInput.required = false;
-            passwordInput.placeholder = 'Leave blank to keep current password';
-
-            // Show password help text
-            document.getElementById('password-help').style.display = 'block';
+            passwordInput.value = '';
+            passwordInput.disabled = true; // disabled fields are excluded from FormData
+            document.getElementById('attendee-password-group').classList.add('hidden');
+            document.getElementById('attendee-reset-group').classList.remove('hidden');
         } else {
             // Reset form for new attendee
             document.getElementById('attendee-form').reset();
-            document.getElementById('attendee-password').required = true;
-            document.getElementById('password-help').style.display = 'none';
+            const passwordInput = document.getElementById('attendee-password');
+            passwordInput.disabled = false;
+            passwordInput.required = true;
+            document.getElementById('attendee-password-group').classList.remove('hidden');
+            document.getElementById('attendee-reset-group').classList.add('hidden');
         }
     },
 
@@ -123,6 +129,10 @@ const AttendeeManagement = {
     bindEvents() {
         // Form submission
         document.getElementById('attendee-form').addEventListener('submit', this.handleSubmit.bind(this));
+
+        // Explicit password reset (edit mode only)
+        const resetBtn = document.getElementById('attendee-reset-password-btn');
+        if (resetBtn) resetBtn.addEventListener('click', this.handleResetPassword.bind(this));
         
         // Close buttons
         document.getElementById('close-attendee-modal').addEventListener('click', this.hideModal.bind(this));
@@ -166,8 +176,9 @@ const AttendeeManagement = {
             }
         });
 
-        // Remove password if empty during edit
-        if (this.isEditing && !data.password) {
+        // A profile edit must never carry a password — the field is disabled in
+        // edit mode, but strip it defensively so nothing can slip through.
+        if (this.isEditing) {
             delete data.password;
         }
 
@@ -198,6 +209,52 @@ const AttendeeManagement = {
             this.showAlert(error.message, 'error');
         } finally {
             Utils.hideLoading(submitBtn);
+        }
+    },
+
+    /**
+     * Explicit password reset for the attendee being edited. The admin can
+     * generate a random temp password or type a specific one; either way the
+     * attendee is flagged to choose their own on next login. If they have an
+     * email on file it's sent to them; the temp password is also shown here so
+     * it can be relayed directly.
+     */
+    async handleResetPassword() {
+        const id = this.editingId;
+        if (!id) return;
+
+        const useGenerated = confirm(
+            'Reset this attendee\'s password?\n\n' +
+            'OK  – generate a temporary password (recommended)\n' +
+            'Cancel – type a specific password'
+        );
+
+        let payload;
+        if (useGenerated) {
+            payload = { notify: true };
+        } else {
+            const pw = prompt('Enter a new password for this attendee (at least 8 characters):');
+            if (!pw) return;
+            if (pw.length < 8) {
+                this.showAlert('Password must be at least 8 characters', 'error');
+                return;
+            }
+            payload = { new_password: pw, notify: true };
+        }
+
+        const btn = document.getElementById('attendee-reset-password-btn');
+        try {
+            if (btn) { btn.disabled = true; }
+            const res = await API.post(`/admin/attendees/${id}/reset-password`, payload);
+            const parts = ['Password reset.'];
+            if (res.emailed) parts.push('A temporary password was emailed to the attendee.');
+            if (res.temp_password) parts.push(`Temporary password: ${res.temp_password}`);
+            parts.push('They will set their own password on next login.');
+            this.showAlert(parts.join(' '), 'success');
+        } catch (error) {
+            this.showAlert('Reset failed: ' + (error.message || error), 'error');
+        } finally {
+            if (btn) { btn.disabled = false; }
         }
     },
 

--- a/frontend/public/js/components/login.js
+++ b/frontend/public/js/components/login.js
@@ -32,6 +32,124 @@ const Login = {
         this.bindPasswordToggle();
         this.bindNavigation();
         this.bindKeyboardShortcuts();
+        this.bindForgotPassword();
+    },
+
+    /**
+     * Wire the "Forgot password?" link (attendee login only).
+     */
+    bindForgotPassword() {
+        const link = document.getElementById('forgot-password-link');
+        if (link) {
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                this.showForgotPasswordForm();
+            });
+        }
+    },
+
+    /**
+     * Swap the login form for the self-service recovery form: reference number
+     * + email, POSTed to /api/forgot-password. The server always replies with
+     * the same generic message (no account enumeration), and emails a temporary
+     * password if the details match — which drops the attendee into the
+     * forced-reset flow on next login.
+     */
+    showForgotPasswordForm() {
+        const container = document.querySelector('.login-form-container');
+        if (!container) return;
+
+        container.innerHTML = `
+            <div class="login-header">
+                <h2>Reset Password</h2>
+                <p>Enter your reference number and the email on your booking — we'll send a temporary password.</p>
+            </div>
+
+            <div id="forgot-alert" class="alert alert-error hidden"></div>
+
+            <form id="forgot-form" class="login-form" novalidate>
+                <div class="form-group">
+                    <label for="forgot-ref" class="form-label-light">Reference Number</label>
+                    <div class="input-with-icon">
+                        <i class="fas fa-id-card input-icon"></i>
+                        <input type="text" id="forgot-ref" class="form-input-light" required
+                               placeholder="Your reference number" autocomplete="username">
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="forgot-email" class="form-label-light">Email</label>
+                    <div class="input-with-icon">
+                        <i class="fas fa-envelope input-icon"></i>
+                        <input type="email" id="forgot-email" class="form-input-light" required
+                               placeholder="Email on your booking" autocomplete="email">
+                    </div>
+                </div>
+
+                <button type="submit" class="btn-signin" id="forgot-btn">
+                    <span id="forgot-text">Send Reset Email</span>
+                    <div id="forgot-spinner" class="loading-spinner hidden"></div>
+                </button>
+            </form>
+
+            <div class="login-footer-links">
+                <a href="#" id="forgot-back-link" class="admin-access-link">
+                    <i class="fas fa-arrow-left"></i> Back to Sign In
+                </a>
+            </div>
+        `;
+
+        const form = document.getElementById('forgot-form');
+        if (form) {
+            form.addEventListener('submit', (ev) => {
+                ev.preventDefault();
+                this._submitForgotPassword();
+            });
+        }
+        const back = document.getElementById('forgot-back-link');
+        if (back) {
+            back.addEventListener('click', async (ev) => {
+                ev.preventDefault();
+                await this.switchToAttendee();
+            });
+        }
+        setTimeout(() => {
+            const el = document.getElementById('forgot-ref');
+            if (el) el.focus();
+        }, 100);
+    },
+
+    async _submitForgotPassword() {
+        const refEl = document.getElementById('forgot-ref');
+        const emailEl = document.getElementById('forgot-email');
+        const ref = refEl ? refEl.value.trim() : '';
+        const email = emailEl ? emailEl.value.trim() : '';
+
+        this.hideAlert('forgot-alert');
+        if (!ref || !email) {
+            this.showAlert('forgot-alert', 'Enter your reference number and email.', 'error');
+            return;
+        }
+
+        const btn = document.getElementById('forgot-btn');
+        try {
+            this.showButtonLoading(btn, 'forgot-spinner', 'forgot-text');
+            const response = await fetch('/api/forgot-password', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ ref, email }),
+            });
+            const body = await response.json().catch(() => ({}));
+            // The endpoint deliberately returns the same message whether or not
+            // an account matched — always show it as success.
+            this.showAlert('forgot-alert',
+                body.message || 'If an account matches those details, a temporary password has been emailed to the address on file.',
+                'success');
+        } catch (err) {
+            this.showAlert('forgot-alert', 'Something went wrong. Please try again in a moment.', 'error');
+        } finally {
+            this.hideButtonLoading(btn, 'forgot-spinner', 'forgot-text', 'Send Reset Email');
+        }
     },
 
     /**

--- a/frontend/public/templates/login.html
+++ b/frontend/public/templates/login.html
@@ -105,6 +105,10 @@
                     </div>
                 </div>
 
+                <div style="text-align: right; margin: -0.25rem 0 0.75rem;">
+                    <a href="#" id="forgot-password-link" style="font-size: 0.85rem; color: #6d28d9; text-decoration: none; font-weight: 600;">Forgot password?</a>
+                </div>
+
                 <button type="submit" class="btn-signin" id="login-btn">
                     <span id="login-text">Sign In</span>
                     <div id="login-spinner" class="loading-spinner hidden"></div>

--- a/frontend/public/templates/modals/attendee-modal.html
+++ b/frontend/public/templates/modals/attendee-modal.html
@@ -50,10 +50,17 @@
                         <input type="text" id="attendee-ref" name="ref_number" class="form-input" required>
                     </div>
 
-                    <div class="form-group">
+                    <div class="form-group" id="attendee-password-group">
                         <label for="attendee-password" class="form-label">Password</label>
-                        <input type="password" id="attendee-password" name="password" class="form-input" required>
-                        <small class="form-help" id="password-help">Leave blank to keep current password when editing</small>
+                        <input type="password" id="attendee-password" name="password" class="form-input" autocomplete="new-password" required>
+                        <small class="form-help" id="password-help">Set the attendee's initial password</small>
+                    </div>
+                    <div class="form-group hidden" id="attendee-reset-group">
+                        <label class="form-label">Password</label>
+                        <button type="button" class="btn btn-secondary" id="attendee-reset-password-btn">
+                            <i class="fas fa-key"></i> Reset Password
+                        </button>
+                        <small class="form-help">Editing a profile never changes the password. Use this to issue a new temporary one — the attendee sets their own on next login.</small>
                     </div>
                 </div>
                 

--- a/functions/_shared/auth.ts
+++ b/functions/_shared/auth.ts
@@ -368,7 +368,7 @@ const MAX_LOGIN_ATTEMPTS_PER_IP = 20;
 export async function checkRateLimit(
   db: D1Database,
   identifier: string,
-  userType: 'admin' | 'attendee',
+  userType: 'admin' | 'attendee' | 'forgot',
   ipAddress?: string | null
 ): Promise<{ allowed: boolean; remainingAttempts: number; resetTime: number; reason?: string }> {
   const windowStart = Date.now() - RATE_LIMIT_WINDOW_MS;
@@ -415,7 +415,7 @@ export async function checkRateLimit(
 export async function recordLoginAttempt(
   db: D1Database,
   identifier: string,
-  userType: 'admin' | 'attendee',
+  userType: 'admin' | 'attendee' | 'forgot',
   success: boolean,
   ipAddress?: string
 ): Promise<void> {

--- a/functions/_shared/temp-password.ts
+++ b/functions/_shared/temp-password.ts
@@ -1,0 +1,11 @@
+// Cryptographically-random temporary password, used by the admin attendee
+// reset and the self-service forgot-password flows. Charset excludes visually
+// ambiguous characters (0/O, 1/l/I) so a temp password read over the phone or
+// out of an email is easy to type. Matches the shape used elsewhere in the app.
+export function generateTempPassword(len = 12): string {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789';
+  const buf = crypto.getRandomValues(new Uint32Array(len));
+  let out = '';
+  for (let i = 0; i < len; i++) out += chars.charAt(buf[i] % chars.length);
+  return out;
+}

--- a/functions/api/admin/attendees/[id].ts
+++ b/functions/api/admin/attendees/[id].ts
@@ -1,7 +1,7 @@
 // Individual attendee operations with TypeScript and validation
 
 import type { PagesContext } from '../../../_shared/types.js';
-import { createResponse, checkAdminAuth, handleCORS, hashPassword } from '../../../_shared/auth.js';
+import { createResponse, checkAdminAuth, handleCORS } from '../../../_shared/auth.js';
 import { validate, attendeeUpdateSchema } from '../../../_shared/validation.js';
 import { errors, createErrorResponse, generateRequestId, handleError } from '../../../_shared/errors.js';
 import { sendRoomAssignedEmail } from '../../../_shared/notifications.js';
@@ -192,20 +192,21 @@ export async function onRequestPut(context: PagesContext<IdParams>): Promise<Res
       }
     }
 
-    // Build dynamic UPDATE query
-    const allowedFields = ['name', 'first_name', 'last_name', 'date_of_birth', 'gender', 'email', 'ref_number', 'room_id', 'group_id', 'payment_due', 'payment_option', 'password'];
+    // Build dynamic UPDATE query.
+    //
+    // NOTE: `password` is deliberately NOT in this list. A profile edit must
+    // never change an attendee's password — otherwise a stray value in the
+    // form's password field (browser/password-manager autofill is the common
+    // culprit) silently re-hashes it and locks the attendee out. Password
+    // changes go through the dedicated /reset-password endpoint (admin) or the
+    // attendee's own change-password / forgot-password flow.
+    const allowedFields = ['name', 'first_name', 'last_name', 'date_of_birth', 'gender', 'email', 'ref_number', 'room_id', 'group_id', 'payment_due', 'payment_option'];
     const updateFields: string[] = [];
     const updateValues: (string | number | null)[] = [];
 
     for (const [key, value] of Object.entries(updateData)) {
       if (allowedFields.includes(key) && value !== undefined) {
-        if (key === 'password') {
-          if (value && typeof value === 'string' && value.trim() !== '') {
-            const hashedPassword = await hashPassword(value);
-            updateFields.push('password_hash = ?');
-            updateValues.push(hashedPassword);
-          }
-        } else if (key === 'gender') {
+        if (key === 'gender') {
           // Normalise to the stored lower-case form; anything else clears it.
           const g = typeof value === 'string' ? value.trim().toLowerCase() : '';
           updateFields.push('gender = ?');

--- a/functions/api/admin/attendees/[id]/reset-password.ts
+++ b/functions/api/admin/attendees/[id]/reset-password.ts
@@ -1,0 +1,126 @@
+// POST /api/admin/attendees/:id/reset-password
+// Body: { new_password?: string, notify?: boolean }
+//
+// Explicit, deliberate password reset for an attendee — the ONLY admin path
+// that changes an attendee's password (profile edits never touch it). If
+// new_password is omitted a random temp password is generated. The account is
+// flagged must_reset_password = 1, so the attendee is walked through setting
+// their own password on next login (the existing forced-reset flow). When
+// notify is true and the attendee has an email on file, the temp password is
+// emailed to them; the password is also returned so the admin can share it
+// directly (e.g. over the phone).
+
+import type { PagesContext } from '../../../../_shared/types.js';
+import { createResponse, checkAdminAuth, handleCORS, hashPassword } from '../../../../_shared/auth.js';
+import { errors, createErrorResponse, generateRequestId, handleError } from '../../../../_shared/errors.js';
+import { generateTempPassword } from '../../../../_shared/temp-password.js';
+import { isEmailReady, sendEmail } from '../../../../_shared/email.js';
+import { escapeHtml } from '../../../../_shared/sanitize.js';
+
+interface IdParams { id: string; }
+
+const MIN_PASSWORD_LENGTH = 8;
+
+export async function onRequestOptions(): Promise<Response> {
+  return handleCORS();
+}
+
+export async function onRequestPost(context: PagesContext<IdParams>): Promise<Response> {
+  const requestId = generateRequestId();
+
+  try {
+    const admin = await checkAdminAuth(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) return createErrorResponse(errors.unauthorized('Invalid or expired token', requestId));
+
+    const id = parseInt(context.params.id, 10);
+    if (!id) return createErrorResponse(errors.badRequest('Attendee id required', requestId));
+
+    const body = await context.request.json().catch(() => ({})) as { new_password?: string; notify?: boolean };
+
+    let password: string;
+    let generated = false;
+    if (typeof body.new_password === 'string' && body.new_password.trim() !== '') {
+      password = body.new_password.trim();
+      if (password.length < MIN_PASSWORD_LENGTH) {
+        return createErrorResponse(errors.badRequest(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`, requestId));
+      }
+    } else {
+      password = generateTempPassword();
+      generated = true;
+    }
+
+    const { results } = await context.env.DB.prepare(
+      'SELECT id, name, email, ref_number FROM attendees WHERE id = ?'
+    ).bind(id).all();
+    if (!results.length) return createErrorResponse(errors.notFound('Attendee', requestId));
+    const attendee = results[0] as { id: number; name: string; email: string | null; ref_number: string };
+
+    const hash = await hashPassword(password);
+    await context.env.DB.prepare(
+      'UPDATE attendees SET password_hash = ?, must_reset_password = 1, updated_at = CURRENT_TIMESTAMP WHERE id = ?'
+    ).bind(hash, id).run();
+
+    // Optionally email the temp password to the attendee.
+    let emailed = false;
+    if (body.notify && attendee.email && isEmailReady(context.env)) {
+      const retreatName = context.env.RETREAT_NAME || 'Growth and Wisdom Retreat';
+      const portalUrl = context.env.PORTAL_URL || 'https://retreat.cloverleafchristiancentre.org';
+      try {
+        emailed = await sendEmail(context.env, {
+          to: attendee.email,
+          subject: `Your portal password has been reset — ${retreatName}`,
+          html: buildResetHtml({ name: attendee.name, ref: attendee.ref_number, tempPassword: password, portalUrl, retreatName }),
+        });
+      } catch (err) {
+        console.warn(`[${requestId}] reset email failed`, err);
+      }
+    }
+
+    try {
+      await context.env.DB.prepare(
+        `INSERT INTO audit_log (admin_user, action, entity_type, entity_id, details)
+         VALUES (?, 'attendee_password_reset', 'attendee', ?, ?)`
+      ).bind(admin.user, id, JSON.stringify({ ref: attendee.ref_number, generated, emailed })).run();
+    } catch (err) {
+      console.warn(`[${requestId}] audit_log write failed`, err);
+    }
+
+    return createResponse({
+      success: true,
+      // Returned so the admin can copy/share it. The attendee must set their
+      // own password on next login (must_reset_password = 1).
+      temp_password: password,
+      generated,
+      emailed,
+      message: `Password reset for ${attendee.name}. They'll set their own password on next login.`,
+    });
+
+  } catch (error) {
+    console.error(`[${requestId}] attendee reset-password error:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}
+
+function buildResetHtml(o: { name: string; ref: string; tempPassword: string; portalUrl: string; retreatName: string }): string {
+  return `
+    <div style="font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; max-width: 560px; margin: 0 auto; background: #f8fafc; padding: 2rem;">
+      <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 1.75rem; text-align: center; border-radius: 12px 12px 0 0;">
+        <h1 style="margin: 0; font-size: 1.35rem;">Your password has been reset</h1>
+        <p style="margin: 0.4rem 0 0 0; opacity: 0.9;">${escapeHtml(o.retreatName)}</p>
+      </div>
+      <div style="background: white; padding: 1.75rem; border-radius: 0 0 12px 12px;">
+        <p style="color:#1f2937; margin:0 0 1rem;">Hi ${escapeHtml(o.name)},</p>
+        <p style="color:#4b5563; margin:0 0 1rem; line-height:1.55;">Your retreat portal password has been reset. Sign in with the temporary password below — you'll be asked to choose your own password straight away.</p>
+        <div style="background:#fef3c7; border:1px solid #fbbf24; padding:1rem 1.25rem; border-radius:8px; margin:1.25rem 0;">
+          <table style="width:100%; border-collapse:collapse;">
+            <tr><td style="padding:0.35rem 0; color:#6b7280; width:45%;">Reference number</td><td style="padding:0.35rem 0; font-family:monospace; font-weight:600; color:#1f2937;">${escapeHtml(o.ref)}</td></tr>
+            <tr><td style="padding:0.35rem 0; color:#6b7280;">Temporary password</td><td style="padding:0.35rem 0; font-family:monospace; font-weight:600; color:#92400e;">${escapeHtml(o.tempPassword)}</td></tr>
+          </table>
+        </div>
+        <div style="text-align:center; margin:1.5rem 0 0.5rem;">
+          <a href="${escapeHtml(o.portalUrl)}" style="display:inline-block; background:linear-gradient(135deg,#667eea,#764ba2); color:white; padding:0.8rem 1.6rem; border-radius:8px; text-decoration:none; font-weight:600;">Open Portal</a>
+        </div>
+        <p style="color:#9ca3af; font-size:0.8rem; margin:1.25rem 0 0; text-align:center;">If you didn't expect this, contact the retreat team.</p>
+      </div>
+    </div>`;
+}

--- a/functions/api/forgot-password.ts
+++ b/functions/api/forgot-password.ts
@@ -1,0 +1,136 @@
+// POST /api/forgot-password
+// Body: { ref: string, email: string }
+//
+// Self-service attendee password recovery. If the reference number and email
+// match an account, a temporary password is generated, stored, the account is
+// flagged must_reset_password = 1, and the temp password is emailed to the
+// address ON FILE (never to a caller-supplied address). The attendee then logs
+// in with the temp password and is walked through choosing their own via the
+// existing forced-reset flow.
+//
+// Security notes:
+//  - Always returns the same generic message whether or not an account matched,
+//    so the endpoint can't be used to enumerate accounts.
+//  - Rate-limited per reference + IP to blunt abuse / reset-spam.
+//  - The temp password only ever goes to the registered email, so a caller who
+//    guesses ref+email can't read it — they can only trigger a reset the real
+//    owner will see.
+
+import type { PagesContext } from '../_shared/types.js';
+import {
+  createResponse,
+  handleCORS,
+  hashPassword,
+  checkRateLimit,
+  recordLoginAttempt,
+} from '../_shared/auth.js';
+import { errors, createErrorResponse, generateRequestId, handleError } from '../_shared/errors.js';
+import { generateTempPassword } from '../_shared/temp-password.js';
+import { isEmailReady, sendEmail } from '../_shared/email.js';
+import { escapeHtml } from '../_shared/sanitize.js';
+
+const GENERIC_MESSAGE =
+  'If an account matches those details, a temporary password has been emailed to the address on file. Sign in with it and you’ll be asked to set a new password.';
+
+export async function onRequestOptions(): Promise<Response> {
+  return handleCORS();
+}
+
+export async function onRequestPost(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+
+  try {
+    const body = await context.request.json().catch(() => ({})) as { ref?: unknown; email?: unknown };
+    const ref = typeof body.ref === 'string' ? body.ref.trim() : '';
+    const email = typeof body.email === 'string' ? body.email.trim() : '';
+
+    if (!ref || !email) {
+      return createErrorResponse(errors.badRequest('Reference number and email are required', requestId));
+    }
+
+    const clientIP = context.request.headers.get('CF-Connecting-IP') ||
+                     context.request.headers.get('X-Forwarded-For') ||
+                     'unknown';
+    const refKey = ref.toUpperCase();
+
+    // Throttle per reference + IP (fails closed on DB error).
+    const rateLimit = await checkRateLimit(context.env.DB, refKey, 'forgot', clientIP);
+    if (!rateLimit.allowed) {
+      return createErrorResponse(errors.rateLimited(Math.ceil((rateLimit.resetTime - Date.now()) / 1000), requestId));
+    }
+
+    // Match on reference + email (both case-insensitive); ignore archived rows
+    // and rows without an email on file.
+    const { results } = await context.env.DB.prepare(`
+      SELECT id, name, email, ref_number
+      FROM attendees
+      WHERE ref_number = ? COLLATE NOCASE
+        AND email = ? COLLATE NOCASE
+        AND email IS NOT NULL AND email != ''
+        AND (is_archived = 0 OR is_archived IS NULL)
+    `).bind(ref, email).all();
+
+    // No match, or email delivery isn't configured — record the attempt and
+    // return the same generic response so nothing is leaked.
+    if (!results.length || !isEmailReady(context.env)) {
+      await recordLoginAttempt(context.env.DB, refKey, 'forgot', false, clientIP);
+      if (results.length && !isEmailReady(context.env)) {
+        console.warn(`[${requestId}] forgot-password matched but email is not configured`);
+      }
+      return createResponse({ success: true, message: GENERIC_MESSAGE });
+    }
+
+    const attendee = results[0] as { id: number; name: string; email: string; ref_number: string };
+
+    const tempPassword = generateTempPassword();
+    const hash = await hashPassword(tempPassword);
+    await context.env.DB.prepare(
+      'UPDATE attendees SET password_hash = ?, must_reset_password = 1, updated_at = CURRENT_TIMESTAMP WHERE id = ?'
+    ).bind(hash, attendee.id).run();
+
+    const retreatName = context.env.RETREAT_NAME || 'Growth and Wisdom Retreat';
+    const portalUrl = context.env.PORTAL_URL || 'https://retreat.cloverleafchristiancentre.org';
+    try {
+      await sendEmail(context.env, {
+        to: attendee.email, // on-file address only
+        subject: `Password reset — ${retreatName}`,
+        html: buildForgotHtml({ name: attendee.name, ref: attendee.ref_number, tempPassword, portalUrl, retreatName }),
+      });
+    } catch (err) {
+      console.warn(`[${requestId}] forgot-password email send failed`, err);
+    }
+
+    // Record as a handled attempt (keeps the rate-limit bucket ticking).
+    await recordLoginAttempt(context.env.DB, refKey, 'forgot', true, clientIP);
+
+    return createResponse({ success: true, message: GENERIC_MESSAGE });
+
+  } catch (error) {
+    console.error(`[${requestId}] forgot-password error:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}
+
+function buildForgotHtml(o: { name: string; ref: string; tempPassword: string; portalUrl: string; retreatName: string }): string {
+  return `
+    <div style="font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; max-width: 560px; margin: 0 auto; background: #f8fafc; padding: 2rem;">
+      <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 1.75rem; text-align: center; border-radius: 12px 12px 0 0;">
+        <h1 style="margin: 0; font-size: 1.35rem;">Reset your portal password</h1>
+        <p style="margin: 0.4rem 0 0 0; opacity: 0.9;">${escapeHtml(o.retreatName)}</p>
+      </div>
+      <div style="background: white; padding: 1.75rem; border-radius: 0 0 12px 12px;">
+        <p style="color:#1f2937; margin:0 0 1rem;">Hi ${escapeHtml(o.name)},</p>
+        <p style="color:#4b5563; margin:0 0 1rem; line-height:1.55;">We received a request to reset your retreat portal password. Sign in with the temporary password below and you'll be asked to choose a new one straight away.</p>
+        <div style="background:#fef3c7; border:1px solid #fbbf24; padding:1rem 1.25rem; border-radius:8px; margin:1.25rem 0;">
+          <table style="width:100%; border-collapse:collapse;">
+            <tr><td style="padding:0.35rem 0; color:#6b7280; width:45%;">Reference number</td><td style="padding:0.35rem 0; font-family:monospace; font-weight:600; color:#1f2937;">${escapeHtml(o.ref)}</td></tr>
+            <tr><td style="padding:0.35rem 0; color:#6b7280;">Temporary password</td><td style="padding:0.35rem 0; font-family:monospace; font-weight:600; color:#92400e;">${escapeHtml(o.tempPassword)}</td></tr>
+          </table>
+        </div>
+        <div style="text-align:center; margin:1.5rem 0 0.5rem;">
+          <a href="${escapeHtml(o.portalUrl)}" style="display:inline-block; background:linear-gradient(135deg,#667eea,#764ba2); color:white; padding:0.8rem 1.6rem; border-radius:8px; text-decoration:none; font-weight:600;">Open Portal</a>
+        </div>
+        <p style="color:#9ca3af; font-size:0.8rem; margin:1.25rem 0 0; text-align:center;">If you didn't request this, you can ignore this email — but consider telling the retreat team.</p>
+      </div>
+    </div>`;
+}

--- a/tests/password-safety.integration.test.ts
+++ b/tests/password-safety.integration.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { env } from 'cloudflare:test';
+import { onRequestPut as putAttendee } from '../functions/api/admin/attendees/[id].js';
+import { onRequestPost as resetPw } from '../functions/api/admin/attendees/[id]/reset-password.js';
+import { onRequestPost as forgot } from '../functions/api/forgot-password.js';
+import { onRequestPost as login } from '../functions/api/login.js';
+import { setupDb, seedAttendee, jsonRequest, adminBearer, ctx } from './helpers/db.js';
+
+async function loginStatus(ref: string, password: string) {
+  const res = await login(ctx(jsonRequest({ ref, password })));
+  return { status: res.status, json: await res.json() as any };
+}
+
+describe('password safety', () => {
+  let id: number;
+
+  beforeEach(async () => {
+    await setupDb();
+    id = await seedAttendee({ ref: 'REF-P1', name: 'Pat Person', password: 'Password123', email: 'pat@example.com' });
+  });
+
+  // The reported bug: editing a profile reset the password.
+  it('a profile edit never changes the password (even if a password is sent)', async () => {
+    const res = await putAttendee(ctx(
+      jsonRequest({ name: 'Renamed Person', password: 'InjectedPass9' }, await adminBearer()),
+      { id: String(id) },
+    ));
+    expect(res.status).toBe(200);
+
+    // Profile field updated…
+    const row = await env.DB.prepare('SELECT name FROM attendees WHERE id = ?').bind(id).first();
+    expect(row!.name).toBe('Renamed Person');
+
+    // …but the original password still works and the injected one does not.
+    expect((await loginStatus('REF-P1', 'Password123')).status).toBe(200);
+    expect((await loginStatus('REF-P1', 'InjectedPass9')).status).toBe(401);
+  });
+
+  describe('admin reset-password', () => {
+    it('generates a temp password and forces a reset on next login', async () => {
+      const res = await resetPw(ctx(jsonRequest({ notify: false }, await adminBearer()), { id: String(id) }));
+      const body = await res.json() as any;
+      expect(res.status).toBe(200);
+      expect(body.generated).toBe(true);
+      expect(typeof body.temp_password).toBe('string');
+      expect(body.temp_password.length).toBeGreaterThanOrEqual(8);
+
+      // Old password dead; temp works but is gated by the forced-reset flow.
+      expect((await loginStatus('REF-P1', 'Password123')).status).toBe(401);
+      const gated = await loginStatus('REF-P1', body.temp_password);
+      expect(gated.status).toBe(403);
+      expect(gated.json.reset_required).toBe(true);
+    });
+
+    it('accepts an admin-specified password', async () => {
+      const res = await resetPw(ctx(jsonRequest({ new_password: 'BrandNewPass1', notify: false }, await adminBearer()), { id: String(id) }));
+      const body = await res.json() as any;
+      expect(res.status).toBe(200);
+      expect(body.generated).toBe(false);
+    });
+
+    it('rejects a too-short password', async () => {
+      const res = await resetPw(ctx(jsonRequest({ new_password: 'short', notify: false }, await adminBearer()), { id: String(id) }));
+      expect(res.status).toBe(400);
+    });
+
+    it('requires admin auth', async () => {
+      const res = await resetPw(ctx(jsonRequest({ notify: false }), { id: String(id) }));
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('forgot-password (self-service)', () => {
+    it('requires both reference number and email', async () => {
+      const res = await forgot(ctx(jsonRequest({ ref: 'REF-P1' })));
+      expect(res.status).toBe(400);
+    });
+
+    it('returns a generic success and does not change the password on a non-match', async () => {
+      const res = await forgot(ctx(jsonRequest({ ref: 'REF-P1', email: 'wrong@example.com' })));
+      expect(res.status).toBe(200);
+      expect((await res.json() as any).success).toBe(true);
+      // Password untouched.
+      expect((await loginStatus('REF-P1', 'Password123')).status).toBe(200);
+    });
+
+    it('does not change the password when email delivery is not configured', async () => {
+      // env has no RESEND_API_KEY/FROM_EMAIL, so isEmailReady() is false.
+      const res = await forgot(ctx(jsonRequest({ ref: 'REF-P1', email: 'pat@example.com' })));
+      expect(res.status).toBe(200);
+      expect((await loginStatus('REF-P1', 'Password123')).status).toBe(200);
+    });
+
+    it('resets the password and forces a reset when ref+email match and email is configured', async () => {
+      // Per-call env override so isEmailReady() is true (DB and other bindings
+      // resolve through the prototype). sendEmail is best-effort; the reset is
+      // applied regardless of delivery.
+      const mailEnv = Object.assign(Object.create(env), {
+        RESEND_API_KEY: 'test-key',
+        FROM_EMAIL: 'noreply@test.local',
+      });
+      const context = {
+        request: jsonRequest({ ref: 'ref-p1', email: 'PAT@example.com' }), // case-insensitive
+        env: mailEnv, params: {}, waitUntil: () => {}, next: async () => new Response(), data: {},
+      };
+      const res = await forgot(context as any);
+      expect(res.status).toBe(200);
+
+      // Old password no longer works; account flagged for forced reset.
+      expect((await loginStatus('REF-P1', 'Password123')).status).toBe(401);
+      const row = await env.DB.prepare('SELECT must_reset_password FROM attendees WHERE ref_number = ?').bind('REF-P1').first();
+      expect(row!.must_reset_password).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## The bug

Editing an attendee's profile could silently **reset their password**. The edit form contained a password field, and browsers / password managers **autofill** it — so an unrelated change (room, group, payment…) shipped a stray password value that got re-hashed, locking the attendee out.

## Password is now fully decoupled from profile editing

- **Removed `password` from the attendee `PUT` allow-list** — a profile update can *never* change the password (defense in depth; even a stray value is ignored).
- The **edit modal hides/disables** the password input and offers an explicit **"Reset Password"** action instead. The **create** form keeps its password field with `autocomplete="new-password"` so it's never autofilled.

## New explicit password paths

- **`POST /api/admin/attendees/:id/reset-password`** — admin issues a temporary password (auto-generated or specified), flags `must_reset_password=1` so the attendee sets their own on next login, and can email it. Returns the temp password so the admin can relay it.
- **`POST /api/forgot-password`** — self-service recovery. Matches on **reference + email**, emails a temp password to the **on-file address only**, flags a forced reset, and always returns a **generic response** (no account enumeration). **Rate-limited under its own bucket** so reset-spam can't lock out a victim's real login. A **"Forgot password?"** link on the attendee login drives it.

Both flows funnel into the **forced-reset screen** already in the app (log in with temp → choose your own password → in).

## Tests
New `password-safety` suite: profile edit preserves the password (the regression), admin reset (generate/specify/short/auth), and forgot-password (match / no-match / email-unconfigured / validation). **107 tests pass**, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR)_