### PR TITLE
feat(admin): "Start New Season" archive + reset tool

### DIFF
--- a/frontend/public/css/components.css
+++ b/frontend/public/css/components.css
@@ -2863,3 +2863,24 @@ select.form-input option,
   vertical-align: middle;
 }
 
+
+/* ===================== Season reset (danger zone) step badges ============== */
+.season-step-num {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(239, 68, 68, 0.15);
+  color: #f87171;
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+#season-panel code {
+  background: rgba(255, 255, 255, 0.06);
+  padding: 0.05rem 0.35rem;
+  border-radius: 4px;
+  font-family: monospace;
+}

--- a/frontend/public/js/components/admin-dashboard.js
+++ b/frontend/public/js/components/admin-dashboard.js
@@ -3485,11 +3485,91 @@ const AdminDashboard = {
             // Reveal super-admin-only nav items.
             if (role === 'super_admin') {
                 document.querySelectorAll('.nav-link.super-only').forEach(el => el.removeAttribute('hidden'));
+                this.bindSeasonPanel();
             }
             this._currentAdmin = me;
         } catch (err) {
             console.warn('Failed to load admin profile', err);
         }
+    },
+
+    /**
+     * "Prepare for Next Season" danger-zone panel (Admins tab, super-admin
+     * only). Three gated steps: download a full backup, attest it's stored +
+     * type the exact confirmation phrase, then run the reset. The reset button
+     * stays disabled until the checkbox is ticked and the phrase matches.
+     */
+    bindSeasonPanel() {
+        const backupBtn = document.getElementById('season-backup-btn');
+        const checkbox = document.getElementById('season-backup-confirm');
+        const phrase = document.getElementById('season-phrase');
+        const resetBtn = document.getElementById('season-reset-btn');
+        const result = document.getElementById('season-result');
+        if (!backupBtn || !resetBtn || backupBtn._bound) return;
+        backupBtn._bound = true;
+
+        const PHRASE = 'RESET FOR NEW SEASON';
+        const updateState = () => {
+            resetBtn.disabled = !(checkbox.checked && phrase.value.trim() === PHRASE);
+        };
+        checkbox.addEventListener('change', updateState);
+        phrase.addEventListener('input', updateState);
+
+        // Step 1 — download the full JSON backup.
+        backupBtn.addEventListener('click', async () => {
+            const orig = backupBtn.innerHTML;
+            backupBtn.disabled = true;
+            backupBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Preparing…';
+            try {
+                const resp = await fetch('/api/admin/season/export', {
+                    headers: { 'Authorization': `Bearer ${Auth.getToken('admin')}` },
+                });
+                if (!resp.ok) throw new Error(`Backup failed (HTTP ${resp.status})`);
+                const blob = await resp.blob();
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `retreat-backup-${new Date().toISOString().split('T')[0]}.json`;
+                a.click();
+                URL.revokeObjectURL(url);
+                checkbox.checked = true;
+                updateState();
+                Utils.showAlert('Backup downloaded. Store it somewhere safe before resetting.', 'success');
+            } catch (e) {
+                Utils.showAlert('Backup failed: ' + (e.message || e), 'error');
+            } finally {
+                backupBtn.disabled = false;
+                backupBtn.innerHTML = orig;
+            }
+        });
+
+        // Step 3 — run the reset (guarded by the phrase + a final confirm).
+        resetBtn.addEventListener('click', async () => {
+            const value = phrase.value.trim();
+            if (value !== PHRASE) return;
+            if (!confirm('FINAL CONFIRMATION\n\nThis permanently deletes ALL attendee and event data. Admin accounts and settings are kept. This cannot be undone.\n\nProceed?')) return;
+
+            const orig = resetBtn.innerHTML;
+            resetBtn.disabled = true;
+            resetBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Resetting…';
+            if (result) result.textContent = '';
+            try {
+                const res = await API.post('/admin/season/reset', { confirm: value });
+                if (result) {
+                    result.style.color = 'var(--success)';
+                    result.textContent = res.message || `Reset complete — cleared ${res.rows_cleared} rows.`;
+                }
+                Utils.showAlert('Season reset complete. Reloading…', 'success');
+                setTimeout(() => window.location.reload(), 2500);
+            } catch (e) {
+                if (result) {
+                    result.style.color = 'var(--error)';
+                    result.textContent = 'Reset failed: ' + (e.message || e);
+                }
+                resetBtn.disabled = false;
+                resetBtn.innerHTML = orig;
+            }
+        });
     },
 
     openChangePassword() {

--- a/frontend/public/templates/admin-dashboard.html
+++ b/frontend/public/templates/admin-dashboard.html
@@ -1067,6 +1067,50 @@
                 </table>
             </div>
         </div>
+
+        <!-- Prepare for Next Season — archive + reset (super-admin only) -->
+        <div class="data-table" id="season-panel" style="border: 1px solid rgba(239,68,68,0.4);">
+            <div class="table-header">
+                <h3 class="table-title" style="color:#f87171;"><i class="fas fa-rotate"></i> Prepare for Next Season</h3>
+            </div>
+            <div style="padding: 1.25rem 1.5rem;">
+                <p style="color:var(--text-secondary); font-size:0.9rem; line-height:1.6; margin:0 0 1.25rem;">
+                    Archive this year and reset the platform for the next retreat. <strong>Admin accounts and settings are kept.</strong>
+                    All attendee and event data — attendees, registrations, payments, rooms, groups, teams, program, announcements,
+                    check-ins, community posts and allergy/medical info — is <strong>permanently cleared</strong>. This can't be undone,
+                    so download the backup first.
+                </p>
+
+                <div style="display:flex; flex-direction:column; gap:1.25rem; max-width:560px;">
+                    <div style="display:flex; align-items:flex-start; gap:0.75rem;">
+                        <span class="season-step-num">1</span>
+                        <div style="flex:1;">
+                            <button class="btn btn-secondary" id="season-backup-btn"><i class="fas fa-download"></i> Download full backup</button>
+                            <div style="font-size:0.78rem; color:var(--text-tertiary); margin-top:0.35rem;">A complete JSON snapshot of every table. Store it somewhere safe before continuing.</div>
+                        </div>
+                    </div>
+
+                    <div style="display:flex; align-items:flex-start; gap:0.75rem;">
+                        <span class="season-step-num">2</span>
+                        <div style="flex:1;">
+                            <label style="display:flex; align-items:flex-start; gap:0.5rem; font-size:0.85rem; color:var(--text-secondary); cursor:pointer;">
+                                <input type="checkbox" id="season-backup-confirm"> I have downloaded and safely stored the backup.
+                            </label>
+                            <label class="form-label" style="margin-top:0.85rem; display:block; font-size:0.8rem;">Type <code style="color:#f87171;">RESET FOR NEW SEASON</code> to confirm</label>
+                            <input type="text" id="season-phrase" class="form-input" placeholder="RESET FOR NEW SEASON" autocomplete="off" style="max-width:360px;">
+                        </div>
+                    </div>
+
+                    <div style="display:flex; align-items:flex-start; gap:0.75rem;">
+                        <span class="season-step-num">3</span>
+                        <div style="flex:1;">
+                            <button class="btn btn-danger" id="season-reset-btn" disabled><i class="fas fa-triangle-exclamation"></i> Reset platform for next season</button>
+                            <div id="season-result" style="font-size:0.82rem; margin-top:0.6rem;"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 
     </div><!-- /.dashboard-main -->

--- a/functions/_shared/season.ts
+++ b/functions/_shared/season.ts
@@ -1,0 +1,33 @@
+// Shared helpers for the annual "Start New Season" archive + reset flow.
+//
+// The reset keeps staff/admin accounts and app configuration and clears every
+// event-specific table. Table discovery is dynamic (from sqlite_master) so the
+// list stays correct as the schema evolves — we only ever have to maintain the
+// small KEEP set below.
+
+import type { D1Database } from '@cloudflare/workers-types';
+
+// Tables preserved across seasons: admin/staff accounts, key/value app config,
+// and the migration bookkeeping table. Everything else is event data and gets
+// cleared. sqlite_* and Cloudflare internal (_cf_*) tables are excluded from
+// discovery entirely.
+export const KEEP_TABLES = ['admins', 'settings', 'd1_migrations'];
+
+// Return the names of all user tables (excluding sqlite/CF-internal tables).
+export async function listUserTables(db: D1Database): Promise<string[]> {
+  const { results } = await db.prepare(`
+    SELECT name FROM sqlite_master
+    WHERE type = 'table'
+      AND name NOT LIKE 'sqlite_%'
+      AND name NOT LIKE '_cf_%'
+    ORDER BY name
+  `).all();
+  return (results as { name: string }[]).map(r => r.name);
+}
+
+// Tables that a reset will clear = all user tables minus the KEEP set.
+export async function tablesToClear(db: D1Database): Promise<string[]> {
+  const all = await listUserTables(db);
+  const keep = new Set(KEEP_TABLES);
+  return all.filter(t => !keep.has(t));
+}

--- a/functions/api/admin/season/export.ts
+++ b/functions/api/admin/season/export.ts
@@ -1,0 +1,61 @@
+// GET /api/admin/season/export
+//
+// Super-admin only. Produces a full JSON snapshot of every table in the
+// database — the restorable backup an admin downloads BEFORE running a season
+// reset. Includes admins/settings too, so the archive is a complete restore
+// point (not just the event data being cleared).
+
+import type { PagesContext } from '../../../_shared/types.js';
+import { requireSuperAdmin, handleCORS } from '../../../_shared/auth.js';
+import { errors, createErrorResponse, generateRequestId, handleError } from '../../../_shared/errors.js';
+import { listUserTables } from '../../../_shared/season.js';
+
+export async function onRequestOptions(): Promise<Response> {
+  return handleCORS();
+}
+
+export async function onRequestGet(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+
+  try {
+    const admin = await requireSuperAdmin(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) return createErrorResponse(errors.forbidden('Super-admin role required', requestId));
+
+    const tables = await listUserTables(context.env.DB);
+    const dump: Record<string, unknown[]> = {};
+    const counts: Record<string, number> = {};
+
+    for (const table of tables) {
+      const { results } = await context.env.DB.prepare(`SELECT * FROM "${table}"`).all();
+      dump[table] = results as unknown[];
+      counts[table] = results.length;
+    }
+
+    const archive = {
+      _meta: {
+        kind: 'retreat-portal-full-backup',
+        version: 1,
+        exported_by: admin.user || 'admin',
+        table_count: tables.length,
+        counts,
+        // NOTE: no timestamp is generated server-side here to keep the handler
+        // deterministic/testable; the download filename carries the date.
+      },
+      tables: dump,
+    };
+
+    const date = new Date().toISOString().split('T')[0];
+    return new Response(JSON.stringify(archive, null, 2), {
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Disposition': `attachment; filename="retreat-backup-${date}.json"`,
+        'Cache-Control': 'no-store',
+        'Access-Control-Allow-Origin': '*',
+      },
+    });
+
+  } catch (error) {
+    console.error(`[${requestId}] season export error:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}

--- a/functions/api/admin/season/reset.ts
+++ b/functions/api/admin/season/reset.ts
@@ -1,0 +1,91 @@
+// POST /api/admin/season/reset
+// Body: { confirm: string }
+//
+// Super-admin only, and gated behind an exact confirmation phrase. Clears every
+// event-specific table (dynamically discovered) while preserving admin/staff
+// accounts and app configuration (see KEEP_TABLES). Used once a year to reset
+// the platform for the next retreat. The admin is expected to have downloaded a
+// full backup (GET /api/admin/season/export) first — the UI enforces that.
+//
+// This is destructive and irreversible. The confirm phrase + super-admin gate
+// are the guardrails; there is intentionally no "are you sure?" shortcut.
+
+import type { PagesContext } from '../../../_shared/types.js';
+import { requireSuperAdmin, handleCORS, createResponse } from '../../../_shared/auth.js';
+import { errors, createErrorResponse, generateRequestId, handleError } from '../../../_shared/errors.js';
+import { tablesToClear, KEEP_TABLES } from '../../../_shared/season.js';
+
+export const CONFIRM_PHRASE = 'RESET FOR NEW SEASON';
+
+export async function onRequestOptions(): Promise<Response> {
+  return handleCORS();
+}
+
+export async function onRequestPost(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+
+  try {
+    const admin = await requireSuperAdmin(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) return createErrorResponse(errors.forbidden('Super-admin role required', requestId));
+
+    const body = await context.request.json().catch(() => ({})) as { confirm?: unknown };
+    const confirm = typeof body.confirm === 'string' ? body.confirm.trim() : '';
+    if (confirm !== CONFIRM_PHRASE) {
+      return createErrorResponse(errors.badRequest(`Confirmation phrase must be exactly "${CONFIRM_PHRASE}"`, requestId));
+    }
+
+    const targets = await tablesToClear(context.env.DB);
+
+    // Count rows first so we can report what was removed.
+    const cleared: Record<string, number> = {};
+    for (const table of targets) {
+      const row = await context.env.DB.prepare(`SELECT COUNT(*) AS c FROM "${table}"`).first();
+      cleared[table] = (row?.c as number) ?? 0;
+    }
+
+    // Atomic wipe of all target tables.
+    if (targets.length > 0) {
+      const stmts = targets.map(t => context.env.DB.prepare(`DELETE FROM "${t}"`));
+      await context.env.DB.batch(stmts);
+    }
+
+    // Reset AUTOINCREMENT counters for the cleared tables so next season's IDs
+    // start clean. Best-effort — sqlite_sequence only exists if some table uses
+    // AUTOINCREMENT, so a failure here must not fail the reset.
+    try {
+      const placeholders = targets.map(() => '?').join(',');
+      if (placeholders) {
+        await context.env.DB.prepare(
+          `DELETE FROM sqlite_sequence WHERE name IN (${placeholders})`
+        ).bind(...targets).run();
+      }
+    } catch (err) {
+      console.warn(`[${requestId}] sqlite_sequence reset skipped`, err);
+    }
+
+    // audit_log was just cleared (it's an event table) — write the reset as the
+    // first entry of the new season so there's a record of who ran it.
+    try {
+      await context.env.DB.prepare(
+        `INSERT INTO audit_log (admin_user, action, entity_type, entity_id, details)
+         VALUES (?, 'season_reset', 'system', 0, ?)`
+      ).bind(admin.user, JSON.stringify({ cleared, kept: KEEP_TABLES })).run();
+    } catch (err) {
+      console.warn(`[${requestId}] audit_log write failed`, err);
+    }
+
+    const totalRows = Object.values(cleared).reduce((a, b) => a + b, 0);
+    return createResponse({
+      success: true,
+      cleared,
+      kept: KEEP_TABLES,
+      tables_cleared: targets.length,
+      rows_cleared: totalRows,
+      message: `Season reset complete — cleared ${totalRows} rows across ${targets.length} tables. Admin accounts and settings were preserved.`,
+    });
+
+  } catch (error) {
+    console.error(`[${requestId}] season reset error:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}

--- a/tests/helpers/schema.ts
+++ b/tests/helpers/schema.ts
@@ -118,6 +118,25 @@ const STATEMENTS = [
     details TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
   )`,
+  // Preserved-across-seasons tables (kept by the season reset).
+  `CREATE TABLE admins (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'admin',
+    full_name TEXT,
+    email TEXT,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    must_reset_password INTEGER NOT NULL DEFAULT 0,
+    last_login DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  )`,
+  `CREATE TABLE settings (
+    key TEXT PRIMARY KEY,
+    value TEXT,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_by TEXT
+  )`,
 ];
 
 export async function createSchema() {

--- a/tests/season.integration.test.ts
+++ b/tests/season.integration.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { env } from 'cloudflare:test';
+import { onRequestPost as resetSeason, CONFIRM_PHRASE } from '../functions/api/admin/season/reset.js';
+import { onRequestGet as exportSeason } from '../functions/api/admin/season/export.js';
+import { setupDb, seedAttendee, jsonRequest, methodRequest, adminBearer, ctx } from './helpers/db.js';
+
+async function seedSome() {
+  await seedAttendee({ ref: 'REF-S1', name: 'Someone' });
+  await seedAttendee({ ref: 'REF-S2', name: 'Another' });
+  await env.DB.prepare('INSERT INTO groups (name) VALUES (?)').bind('Team Alpha').run();
+  await env.DB.prepare("INSERT INTO announcements (title, content) VALUES ('Welcome', 'Hi')").run();
+  await env.DB.prepare(
+    "INSERT INTO admins (username, password_hash, role) VALUES ('super', 'x', 'super_admin')"
+  ).run();
+  await env.DB.prepare("INSERT INTO settings (key, value) VALUES ('retreat_name', '2026')").run();
+}
+
+async function count(table: string): Promise<number> {
+  const row = await env.DB.prepare(`SELECT COUNT(*) AS c FROM ${table}`).first();
+  return (row!.c as number);
+}
+
+describe('season reset', () => {
+  beforeEach(async () => {
+    await setupDb();
+    await seedSome();
+  });
+
+  it('requires a super-admin', async () => {
+    // Regular admin token
+    const asAdmin = await resetSeason(ctx(jsonRequest({ confirm: CONFIRM_PHRASE }, await adminBearer('Reg', 'admin'))));
+    expect(asAdmin.status).toBe(403);
+    // No token
+    const noAuth = await resetSeason(ctx(jsonRequest({ confirm: CONFIRM_PHRASE })));
+    expect(noAuth.status).toBe(403);
+  });
+
+  it('requires the exact confirmation phrase', async () => {
+    const res = await resetSeason(ctx(jsonRequest({ confirm: 'reset' }, await adminBearer())));
+    expect(res.status).toBe(400);
+    // And nothing was cleared.
+    expect(await count('attendees')).toBe(2);
+  });
+
+  it('clears event data but keeps admins and settings', async () => {
+    expect(await count('attendees')).toBe(2);
+
+    const res = await resetSeason(ctx(jsonRequest({ confirm: CONFIRM_PHRASE }, await adminBearer('Boss', 'super_admin'))));
+    const body = await res.json() as any;
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.rows_cleared).toBeGreaterThan(0);
+    expect(body.kept).toContain('admins');
+    expect(body.kept).toContain('settings');
+
+    // Event tables emptied…
+    expect(await count('attendees')).toBe(0);
+    expect(await count('groups')).toBe(0);
+    expect(await count('announcements')).toBe(0);
+
+    // …preserved tables intact.
+    expect(await count('admins')).toBe(1);
+    expect(await count('settings')).toBe(1);
+
+    // The reset itself is recorded as the first entry of the new season.
+    const audit = await env.DB.prepare("SELECT action FROM audit_log WHERE action = 'season_reset'").first();
+    expect(audit).toBeTruthy();
+  });
+});
+
+describe('season export', () => {
+  beforeEach(async () => {
+    await setupDb();
+    await seedSome();
+  });
+
+  it('requires a super-admin', async () => {
+    const asAdmin = await exportSeason(ctx(methodRequest('GET', await adminBearer('Reg', 'admin'))));
+    expect(asAdmin.status).toBe(403);
+  });
+
+  it('returns a full JSON archive of every table', async () => {
+    const res = await exportSeason(ctx(methodRequest('GET', await adminBearer())));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('application/json');
+    const body = await res.json() as any;
+    expect(body._meta.kind).toBe('retreat-portal-full-backup');
+    // Seeded rows are present in the dump.
+    expect(body.tables.attendees.length).toBe(2);
+    expect(body.tables.admins.length).toBe(1);
+    expect(body.tables.settings.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

A reusable, guarded **annual reset** so the platform can be prepared for next year's retreat — *archive → reset*, never a blind wipe. Super-admin only, lives in the (already gated) **Admins** tab as a "Prepare for Next Season" danger zone.

### Three deliberate steps
1. **Download full backup** — `GET /api/admin/season/export` returns a complete JSON snapshot of every table (the restorable backup).
2. **Attest + confirm** — tick "backup stored" and type the exact phrase `RESET FOR NEW SEASON`.
3. **Reset** — button stays disabled until both are satisfied, then a final confirm dialog.

### The reset (`POST /api/admin/season/reset`)
- Requires **super-admin** *and* the exact confirmation phrase.
- **Keeps** admin/staff accounts and app settings (`KEEP` set: `admins`, `settings`, `d1_migrations`).
- **Clears** every other (event-specific) table — attendees, registrations, payments, rooms, groups, teams, program, announcements, check-ins, community posts, allergy/medical, login history, push subs, etc.
- Atomic batch delete, resets AUTOINCREMENT counters, and records the reset as the first audit-log entry of the new season. Returns per-table cleared counts.

Table discovery is **dynamic** (`sqlite_master`), so the keep/clear split stays correct as the schema evolves.

## Tests
Super-admin gate, exact-phrase gate, "clears event tables but keeps admins/settings", audit entry, and the export dump. **112 tests pass**, `tsc` clean.

## ⚠️ Note
Deploying this PR only ships the *tool* — it changes no data. The actual archive + reset is a separate, deliberate action (download backup → type phrase → confirm), and running it against production also needs the Cloudflare connector re-authorized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR)_