### PR TITLE
feat(admin): editable retreat information per year (Settings page)

### DIFF
--- a/frontend/public/js/components/admin-dashboard.js
+++ b/frontend/public/js/components/admin-dashboard.js
@@ -2219,6 +2219,11 @@ const AdminDashboard = {
                     this.loadCommunityPosts();
                 }
 
+                // Retreat settings editor
+                if (tabName === 'settings') {
+                    this.loadRetreatSettings();
+                }
+
                 // Lazy-load allergy registry
                 if (tabName === 'allergies' && window.AllergyRegistry) {
                     if (!window.AllergyRegistry._initialised) {
@@ -3584,6 +3589,66 @@ const AdminDashboard = {
             body: JSON.stringify({ current_password: current, new_password: next }),
         }).then(() => Utils.showAlert('Password updated', 'success'))
           .catch(err => Utils.showAlert('Failed: ' + (err.message || err), 'error'));
+    },
+
+    /**
+     * Retreat Information (Settings tab) — load the current config into the
+     * form and save edits back. Powers the login/registration branding + prices.
+     */
+    async loadRetreatSettings() {
+        const form = document.getElementById('retreat-settings-form');
+        if (!form) return;
+        if (!form._bound) {
+            form._bound = true;
+            form.addEventListener('submit', (e) => this.saveRetreatSettings(e));
+        }
+        try {
+            const cfg = await API.get('/admin/settings/retreat');
+            const set = (id, v) => { const el = document.getElementById(id); if (el && v !== undefined && v !== null) el.value = v; };
+            set('cfg-name', cfg.name);
+            set('cfg-tagline', cfg.tagline);
+            set('cfg-scripture', cfg.scripture);
+            set('cfg-dates', cfg.dates);
+            set('cfg-venue', cfg.venue);
+            set('cfg-host', cfg.host);
+            set('cfg-price-adult', cfg.price_adult);
+            set('cfg-price-child', cfg.price_child);
+            set('cfg-price-infant', cfg.price_infant);
+        } catch (e) {
+            Utils.showAlert('Failed to load retreat settings: ' + (e.message || e), 'error');
+        }
+    },
+
+    async saveRetreatSettings(e) {
+        if (e) e.preventDefault();
+        const val = (id) => { const el = document.getElementById(id); return el ? el.value.trim() : ''; };
+        const payload = {
+            name: val('cfg-name'),
+            tagline: val('cfg-tagline'),
+            scripture: val('cfg-scripture'),
+            dates: val('cfg-dates'),
+            venue: val('cfg-venue'),
+            host: val('cfg-host'),
+        };
+        ['adult', 'child', 'infant'].forEach(k => {
+            const el = document.getElementById('cfg-price-' + k);
+            if (el && el.value !== '') payload['price_' + k] = Number(el.value);
+        });
+        // Don't send blank strings — the server rejects empty required fields.
+        Object.keys(payload).forEach(k => { if (payload[k] === '') delete payload[k]; });
+
+        const alert = document.getElementById('retreat-settings-alert');
+        const btn = document.getElementById('retreat-settings-save');
+        try {
+            if (btn) btn.disabled = true;
+            await API.request('/admin/settings/retreat', { method: 'PUT', body: JSON.stringify(payload) });
+            if (alert) alert.classList.add('hidden');
+            Utils.showAlert('Retreat information updated — the login and registration pages now show the new details.', 'success');
+        } catch (err) {
+            if (alert) { alert.className = 'alert alert-error'; alert.textContent = err.message || 'Save failed'; alert.classList.remove('hidden'); }
+        } finally {
+            if (btn) btn.disabled = false;
+        }
     },
 
     // ==================== ENHANCEMENT FEATURES ====================

--- a/frontend/public/js/components/login.js
+++ b/frontend/public/js/components/login.js
@@ -10,6 +10,28 @@ const Login = {
         this.bindEvents();
         this.setupValidation();
         this.setupAccessibility();
+        this.applyRetreatConfig();
+    },
+
+    /**
+     * Pull the current retreat details (name, theme, scripture, dates, venue,
+     * host) from /api/config and drop them into any [data-config] element, so
+     * the landing page always shows this year's info without a redeploy. Silent
+     * no-op on failure — the template's baked-in defaults stay put.
+     */
+    async applyRetreatConfig() {
+        try {
+            const cfg = await API.get('/config');
+            document.querySelectorAll('[data-config]').forEach(el => {
+                const key = el.getAttribute('data-config');
+                if (cfg[key] !== undefined && cfg[key] !== null && String(cfg[key]).trim() !== '') {
+                    el.textContent = cfg[key];
+                }
+            });
+            if (cfg.name) document.title = cfg.name + ' — Portal';
+        } catch (_) {
+            /* keep the template defaults */
+        }
     },
 
     /**
@@ -687,7 +709,8 @@ const Login = {
         this.bindEvents();
         this.setupValidation();
         this.setupAccessibility();
-        
+        this.applyRetreatConfig();
+
         // Focus on reference field
         setTimeout(() => {
             document.getElementById('login-ref').focus();

--- a/frontend/public/register.html
+++ b/frontend/public/register.html
@@ -628,12 +628,12 @@
 <body>
     <div class="container">
         <div class="header">
-            <h1><i class="fas fa-mountain"></i> Growth & Wisdom Family Retreat 2026</h1>
-            <p class="header-theme">"The Abundant Life"</p>
-            <p class="header-scripture"><i class="fas fa-book-open"></i> John 10:10 — "I have come that they may have life, and have it to the full."</p>
+            <h1><i class="fas fa-mountain"></i> <span data-config="name">Growth &amp; Wisdom Family Retreat 2026</span></h1>
+            <p class="header-theme">&ldquo;<span data-config="tagline">The Abundant Life</span>&rdquo;</p>
+            <p class="header-scripture"><i class="fas fa-book-open"></i> <span data-config="scripture">John 10:10 — "I have come that they may have life, and have it to the full."</span></p>
             <div class="header-details">
-                <span><i class="fas fa-calendar-alt"></i> July 31 - August 2, 2026</span>
-                <span><i class="fas fa-map-marker-alt"></i> The Hayes, Swanwick, Derbyshire</span>
+                <span><i class="fas fa-calendar-alt"></i> <span data-config="dates">July 31 - August 2, 2026</span></span>
+                <span><i class="fas fa-map-marker-alt"></i> <span data-config="venue">The Hayes, Swanwick, Derbyshire</span></span>
             </div>
         </div>
 
@@ -644,15 +644,15 @@
                     <h3><i class="fas fa-tag"></i> Retreat Pricing</h3>
                     <div class="pricing-grid">
                         <div class="pricing-item">
-                            <div class="price">£200</div>
+                            <div class="price" id="price-adult">£200</div>
                             <div class="label">Adults (17+)</div>
                         </div>
                         <div class="pricing-item">
-                            <div class="price">£60</div>
+                            <div class="price" id="price-child">£60</div>
                             <div class="label">Children (6-16 years)</div>
                         </div>
                         <div class="pricing-item free">
-                            <div class="price">FREE</div>
+                            <div class="price" id="price-infant">FREE</div>
                             <div class="label">Under 6 years</div>
                         </div>
                     </div>
@@ -837,12 +837,40 @@
     </div>
 
     <script>
-        // Pricing constants
+        // Pricing constants (overridden from /api/config at load so the form
+        // always reflects the admin-configured, current-year prices).
         const PRICING = {
             adult: 200,      // 17+
             child: 60,       // 6-16
             infant: 0        // Under 6
         };
+
+        // Pull the current retreat details + prices and apply them to the page.
+        async function applyRetreatConfig() {
+            try {
+                const resp = await fetch('/api/config');
+                if (!resp.ok) return;
+                const cfg = await resp.json();
+                document.querySelectorAll('[data-config]').forEach(el => {
+                    const k = el.getAttribute('data-config');
+                    if (cfg[k] !== undefined && cfg[k] !== null && String(cfg[k]).trim() !== '') {
+                        el.textContent = cfg[k];
+                    }
+                });
+                if (cfg.name) document.title = 'Register — ' + cfg.name;
+                const fmt = (n) => (Number(n) === 0 ? 'FREE' : '£' + n);
+                const setPrice = (field, id) => {
+                    if (typeof cfg[field] === 'number') {
+                        PRICING[field.replace('price_', '')] = cfg[field];
+                        const el = document.getElementById(id);
+                        if (el) el.textContent = fmt(cfg[field]);
+                    }
+                };
+                setPrice('price_adult', 'price-adult');
+                setPrice('price_child', 'price-child');
+                setPrice('price_infant', 'price-infant');
+            } catch (_) { /* keep template defaults */ }
+        }
 
         let memberCount = 1;
 
@@ -1006,6 +1034,9 @@
 
         // Initialize
         document.addEventListener('DOMContentLoaded', async () => {
+            // Apply the current-year retreat details + prices first.
+            await applyRetreatConfig();
+
             // If an admin has closed registration, replace the form with a
             // notice and skip wiring the (now-absent) form controls.
             try {

--- a/frontend/public/templates/admin-dashboard.html
+++ b/frontend/public/templates/admin-dashboard.html
@@ -41,6 +41,7 @@
                 <span class="nav-section-label">System</span>
                 <button class="tab-btn nav-link" data-tab="analytics"><i class="fas fa-chart-pie"></i> Analytics</button>
                 <button class="tab-btn nav-link" data-tab="reports"><i class="fas fa-chart-bar"></i> Reports</button>
+                <button class="tab-btn nav-link" data-tab="settings"><i class="fas fa-sliders"></i> Settings</button>
                 <button class="tab-btn nav-link super-only" data-tab="admins" hidden><i class="fas fa-user-shield"></i> Admins</button>
             </div>
         </nav>
@@ -1042,6 +1043,69 @@
     </div>
 
     <!-- Admin Management Tab (super-admin only — nav link is hidden for non-super) -->
+    <!-- Settings Tab: editable retreat information (per-year) -->
+    <div class="tab-content" id="settings-tab">
+        <div class="data-table">
+            <div class="table-header">
+                <h3 class="table-title"><i class="fas fa-sliders"></i> Retreat Information</h3>
+                <button class="btn btn-sm btn-primary" id="retreat-settings-save" form="retreat-settings-form" type="submit">
+                    <i class="fas fa-save"></i> Save Changes
+                </button>
+            </div>
+            <div style="padding: 1.25rem 1.5rem;">
+                <p style="color:var(--text-secondary); font-size:0.88rem; margin:0 0 1.25rem;">
+                    These details appear on the login and registration pages. Update them each year — they're kept when you start a new season.
+                </p>
+                <div id="retreat-settings-alert" class="alert alert-error hidden" style="margin-bottom:1rem;"></div>
+                <form id="retreat-settings-form">
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label class="form-label" for="cfg-name">Retreat name</label>
+                            <input type="text" id="cfg-name" name="name" class="form-input" maxlength="120" placeholder="Growth & Wisdom Family Retreat 2027">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="cfg-tagline">Theme / tagline</label>
+                            <input type="text" id="cfg-tagline" name="tagline" class="form-input" maxlength="120" placeholder="The Abundant Life">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="cfg-scripture">Scripture</label>
+                        <textarea id="cfg-scripture" name="scripture" class="form-input" rows="2" maxlength="500" placeholder='John 10:10 — "..."'></textarea>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label class="form-label" for="cfg-dates">Dates</label>
+                            <input type="text" id="cfg-dates" name="dates" class="form-input" maxlength="120" placeholder="July 30 – August 1, 2027">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="cfg-venue">Venue</label>
+                            <input type="text" id="cfg-venue" name="venue" class="form-input" maxlength="160" placeholder="The Hayes, Swanwick, Derbyshire">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="cfg-host">Host</label>
+                        <input type="text" id="cfg-host" name="host" class="form-input" maxlength="160" placeholder="Cloverleaf Christian Centre">
+                    </div>
+                    <h4 style="margin:1.25rem 0 0.5rem; color:var(--text-primary);"><i class="fas fa-tag"></i> Pricing (£)</h4>
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label class="form-label" for="cfg-price-adult">Adult (17+)</label>
+                            <input type="number" id="cfg-price-adult" name="price_adult" class="form-input" min="0" step="1" placeholder="200">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="cfg-price-child">Child (6–16)</label>
+                            <input type="number" id="cfg-price-child" name="price_child" class="form-input" min="0" step="1" placeholder="60">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="cfg-price-infant">Under 6</label>
+                            <input type="number" id="cfg-price-infant" name="price_infant" class="form-input" min="0" step="1" placeholder="0">
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
     <div class="tab-content" id="admins-tab">
         <div class="data-table" style="margin-bottom: 1.5rem;">
             <div class="table-header">

--- a/frontend/public/templates/login.html
+++ b/frontend/public/templates/login.html
@@ -5,27 +5,27 @@
             <div class="brand-logo">
                 <img src="logo.png" alt="Retreat Logo" class="brand-logo-img">
             </div>
-            <h1 class="brand-title">Growth & Wisdom<br>Family Retreat 2026</h1>
+            <h1 class="brand-title" data-config="name">Growth &amp; Wisdom Family Retreat 2026</h1>
             <div class="brand-theme">
-                <span class="theme-label">"The Abundant Life"</span>
+                <span class="theme-label">&ldquo;<span data-config="tagline">The Abundant Life</span>&rdquo;</span>
             </div>
             <p class="brand-scripture">
                 <i class="fas fa-book-open"></i>
-                John 10:10 — "I have come that they may have life, and have it to the full."
+                <span data-config="scripture">John 10:10 — "I have come that they may have life, and have it to the full."</span>
             </p>
 
             <div class="brand-details">
                 <div class="brand-detail-item">
                     <i class="fas fa-calendar-alt"></i>
-                    <span>July 31 - August 2, 2026</span>
+                    <span data-config="dates">July 31 - August 2, 2026</span>
                 </div>
                 <div class="brand-detail-item">
                     <i class="fas fa-map-marker-alt"></i>
-                    <span>The Hayes, Swanwick, Derbyshire</span>
+                    <span data-config="venue">The Hayes, Swanwick, Derbyshire</span>
                 </div>
                 <div class="brand-detail-item">
                     <i class="fas fa-church"></i>
-                    <span>Hosted by Cloverleaf Christian Centre</span>
+                    <span>Hosted by <span data-config="host">Cloverleaf Christian Centre</span></span>
                 </div>
             </div>
 

--- a/functions/_shared/retreat-config.ts
+++ b/functions/_shared/retreat-config.ts
@@ -1,0 +1,92 @@
+// Editable, per-year retreat information (name, theme, scripture, dates, venue,
+// host, pricing). Stored in the generic `settings` k/v table so it survives the
+// annual "Start New Season" reset, and edited from the admin Settings page.
+// Everything falls back to sensible defaults when a key has never been set, so
+// the app renders correctly on a fresh database.
+
+import { setSetting } from './settings.js';
+
+export interface RetreatConfig {
+  name: string;
+  tagline: string;
+  scripture: string;
+  dates: string;
+  venue: string;
+  host: string;
+  price_adult: number;
+  price_child: number;
+  price_infant: number;
+}
+
+export const RETREAT_CONFIG_DEFAULTS: RetreatConfig = {
+  name: 'Growth & Wisdom Family Retreat 2026',
+  tagline: 'The Abundant Life',
+  scripture: 'John 10:10 — "I have come that they may have life, and have it to the full."',
+  dates: 'July 31 - August 2, 2026',
+  venue: 'The Hayes, Swanwick, Derbyshire',
+  host: 'Cloverleaf Christian Centre',
+  price_adult: 200,
+  price_child: 60,
+  price_infant: 0,
+};
+
+// config field -> settings key
+const KEY: Record<keyof RetreatConfig, string> = {
+  name: 'retreat_name',
+  tagline: 'retreat_tagline',
+  scripture: 'retreat_scripture',
+  dates: 'retreat_dates',
+  venue: 'retreat_venue',
+  host: 'retreat_host',
+  price_adult: 'price_adult',
+  price_child: 'price_child',
+  price_infant: 'price_infant',
+};
+
+export const STRING_FIELDS: (keyof RetreatConfig)[] = ['name', 'tagline', 'scripture', 'dates', 'venue', 'host'];
+export const PRICE_FIELDS: (keyof RetreatConfig)[] = ['price_adult', 'price_child', 'price_infant'];
+
+// Read the whole config in a single query (the settings table is tiny), layering
+// stored values over the defaults.
+export async function getRetreatConfig(db: D1Database): Promise<RetreatConfig> {
+  const cfg: RetreatConfig = { ...RETREAT_CONFIG_DEFAULTS };
+  try {
+    const { results } = await db.prepare('SELECT key, value FROM settings').all();
+    const map = new Map<string, string | null>();
+    for (const r of results as { key: string; value: string | null }[]) map.set(r.key, r.value);
+
+    for (const f of STRING_FIELDS) {
+      const v = map.get(KEY[f]);
+      if (typeof v === 'string' && v.trim() !== '') (cfg[f] as string) = v;
+    }
+    for (const f of PRICE_FIELDS) {
+      const v = map.get(KEY[f]);
+      if (v !== undefined && v !== null && v !== '') {
+        const n = Number(v);
+        if (Number.isFinite(n) && n >= 0) (cfg[f] as number) = n;
+      }
+    }
+  } catch {
+    // settings table missing / query failed — defaults are fine.
+  }
+  return cfg;
+}
+
+// Persist only the provided fields. Prices coerced to non-negative numbers.
+export async function setRetreatConfig(
+  db: D1Database,
+  partial: Partial<RetreatConfig>,
+  adminUser: string,
+): Promise<void> {
+  for (const f of STRING_FIELDS) {
+    const v = partial[f];
+    if (v !== undefined) await setSetting(db, KEY[f], String(v), adminUser);
+  }
+  for (const f of PRICE_FIELDS) {
+    const v = partial[f];
+    if (v !== undefined) {
+      const n = Math.max(0, Number(v) || 0);
+      await setSetting(db, KEY[f], String(n), adminUser);
+    }
+  }
+}

--- a/functions/api/admin/settings/retreat.ts
+++ b/functions/api/admin/settings/retreat.ts
@@ -1,0 +1,100 @@
+// GET/PUT /api/admin/settings/retreat
+//
+// Read or update the per-year retreat information shown on the login and
+// registration pages (name, tagline, scripture, dates, venue, host, pricing).
+// PUT accepts any subset of those fields.
+
+import type { PagesContext } from '../../../_shared/types.js';
+import { createResponse, checkAdminAuth, handleCORS } from '../../../_shared/auth.js';
+import { errors, createErrorResponse, generateRequestId, handleError } from '../../../_shared/errors.js';
+import {
+  getRetreatConfig,
+  setRetreatConfig,
+  STRING_FIELDS,
+  PRICE_FIELDS,
+  type RetreatConfig,
+} from '../../../_shared/retreat-config.js';
+
+const MAX_LENGTHS: Record<string, number> = {
+  name: 120,
+  tagline: 120,
+  scripture: 500,
+  dates: 120,
+  venue: 160,
+  host: 160,
+};
+const MAX_PRICE = 100000;
+
+export async function onRequestOptions(): Promise<Response> {
+  return handleCORS();
+}
+
+export async function onRequestGet(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+  try {
+    const admin = await checkAdminAuth(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) return createErrorResponse(errors.unauthorized('Invalid or expired token', requestId));
+
+    const config = await getRetreatConfig(context.env.DB);
+    return createResponse(config);
+  } catch (error) {
+    console.error(`[${requestId}] retreat settings GET error:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}
+
+export async function onRequestPut(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+  try {
+    const admin = await checkAdminAuth(context.request, context.env.JWT_SECRET || context.env.ADMIN_JWT_SECRET);
+    if (!admin) return createErrorResponse(errors.unauthorized('Invalid or expired token', requestId));
+
+    const body = await context.request.json().catch(() => ({})) as Record<string, unknown>;
+    const partial: Partial<RetreatConfig> = {};
+
+    for (const f of STRING_FIELDS) {
+      if (body[f] === undefined) continue;
+      if (typeof body[f] !== 'string') {
+        return createErrorResponse(errors.badRequest(`${f} must be text`, requestId));
+      }
+      const v = (body[f] as string).trim();
+      if (v === '') {
+        return createErrorResponse(errors.badRequest(`${f} cannot be empty`, requestId));
+      }
+      if (v.length > (MAX_LENGTHS[f] ?? 200)) {
+        return createErrorResponse(errors.badRequest(`${f} is too long (max ${MAX_LENGTHS[f]})`, requestId));
+      }
+      (partial[f] as string) = v;
+    }
+
+    for (const f of PRICE_FIELDS) {
+      if (body[f] === undefined) continue;
+      const n = Number(body[f]);
+      if (!Number.isFinite(n) || n < 0 || n > MAX_PRICE) {
+        return createErrorResponse(errors.badRequest(`${f} must be a number between 0 and ${MAX_PRICE}`, requestId));
+      }
+      (partial[f] as number) = Math.round(n * 100) / 100;
+    }
+
+    if (Object.keys(partial).length === 0) {
+      return createErrorResponse(errors.badRequest('No valid fields to update', requestId));
+    }
+
+    await setRetreatConfig(context.env.DB, partial, admin.user);
+
+    try {
+      await context.env.DB.prepare(
+        `INSERT INTO audit_log (admin_user, action, entity_type, entity_id, details)
+         VALUES (?, 'update_retreat_config', 'settings', 0, ?)`
+      ).bind(admin.user, JSON.stringify({ fields: Object.keys(partial) })).run();
+    } catch (err) {
+      console.warn(`[${requestId}] audit_log write failed`, err);
+    }
+
+    const updated = await getRetreatConfig(context.env.DB);
+    return createResponse(updated);
+  } catch (error) {
+    console.error(`[${requestId}] retreat settings PUT error:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}

--- a/functions/api/config.ts
+++ b/functions/api/config.ts
@@ -1,0 +1,28 @@
+// GET /api/config
+//
+// Public, unauthenticated. Returns the editable retreat information (name,
+// theme, scripture, dates, venue, host, pricing) plus whether registration is
+// open, so the login and registration pages can render the current year's
+// details without a redeploy. Values fall back to defaults when unset.
+
+import type { PagesContext } from '../_shared/types.js';
+import { createResponse, handleCORS } from '../_shared/auth.js';
+import { createErrorResponse, generateRequestId, handleError } from '../_shared/errors.js';
+import { getRetreatConfig } from '../_shared/retreat-config.js';
+import { getRegistrationsOpen } from '../_shared/settings.js';
+
+export async function onRequestOptions(): Promise<Response> {
+  return handleCORS();
+}
+
+export async function onRequestGet(context: PagesContext): Promise<Response> {
+  const requestId = generateRequestId();
+  try {
+    const config = await getRetreatConfig(context.env.DB);
+    const registrations_open = await getRegistrationsOpen(context.env.DB);
+    return createResponse({ ...config, registrations_open });
+  } catch (error) {
+    console.error(`[${requestId}] config GET error:`, error);
+    return createErrorResponse(handleError(error, requestId));
+  }
+}

--- a/functions/api/register.ts
+++ b/functions/api/register.ts
@@ -7,6 +7,7 @@ import { errors, createErrorResponse, generateRequestId, handleError } from '../
 import { escapeHtml } from '../_shared/sanitize.js';
 import { sendEmailOrThrow, isEmailReady } from '../_shared/email.js';
 import { getRegistrationsOpen } from '../_shared/settings.js';
+import { getRetreatConfig } from '../_shared/retreat-config.js';
 
 // Pricing constants
 const PRICING = {
@@ -53,13 +54,14 @@ export async function onRequestGet(context: PagesContext): Promise<Response> {
     // Return public info about registration options
     const roomTypes = ['family', 'single', 'double', 'suite', 'standard'];
     const registrationsOpen = await getRegistrationsOpen(context.env.DB);
+    const cfg = await getRetreatConfig(context.env.DB);
 
     return createResponse({
       roomTypes,
       pricing: {
-        adult: { price: PRICING.adult, description: 'Adults (17+ years)' },
-        child: { price: PRICING.child, description: 'Children (6-16 years)' },
-        infant: { price: PRICING.infant, description: 'Under 6 years (FREE)' }
+        adult: { price: cfg.price_adult, description: 'Adults (17+ years)' },
+        child: { price: cfg.price_child, description: 'Children (6-16 years)' },
+        infant: { price: cfg.price_infant, description: 'Under 6 years (FREE)' }
       },
       registrationsOpen,
       message: registrationsOpen
@@ -171,8 +173,13 @@ export async function onRequestPost(context: PagesContext): Promise<Response> {
       ));
     }
 
-    // Calculate total and verify
-    const calculatedTotal = calculateTotal(data.members);
+    // Calculate total and verify, using the configured per-year prices.
+    const cfg = await getRetreatConfig(context.env.DB);
+    const calculatedTotal = calculateTotal(data.members, {
+      adult: cfg.price_adult,
+      child: cfg.price_child,
+      infant: cfg.price_infant,
+    });
     const primaryMember = data.members[0];
 
     // Insert new registration with family members as JSON
@@ -261,12 +268,16 @@ function validateRegistration(body: Record<string, unknown>): Array<{field: stri
   return validationErrors;
 }
 
-// Calculate total amount based on members
-function calculateTotal(members: FamilyMember[]): number {
+// Calculate total amount based on members, using the configured per-year prices
+// (falls back to the PRICING defaults when not supplied).
+function calculateTotal(
+  members: FamilyMember[],
+  pricing: { adult: number; child: number; infant: number } = PRICING,
+): number {
   return members.reduce((total, member) => {
-    if (member.member_type === 'adult') return total + PRICING.adult;
-    if (member.member_type === 'child') return total + PRICING.child;
-    return total; // infant is free
+    if (member.member_type === 'adult') return total + pricing.adult;
+    if (member.member_type === 'child') return total + pricing.child;
+    return total + pricing.infant; // infants free by default
   }, 0);
 }
 

--- a/tests/retreat-config.integration.test.ts
+++ b/tests/retreat-config.integration.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { onRequestGet as publicConfig } from '../functions/api/config.js';
+import { onRequestGet as getRetreat, onRequestPut as putRetreat } from '../functions/api/admin/settings/retreat.js';
+import { onRequestGet as registerInfo } from '../functions/api/register.js';
+import { setupDb, jsonRequest, methodRequest, adminBearer, ctx } from './helpers/db.js';
+
+async function getConfig() {
+  const res = await publicConfig(ctx(methodRequest('GET')));
+  return { status: res.status, json: await res.json() as any };
+}
+async function putConfig(body: any, headers?: Record<string, string>) {
+  const res = await putRetreat(ctx(jsonRequest(body, headers ?? await adminBearer())));
+  return { status: res.status, json: await res.json().catch(() => ({})) as any };
+}
+
+describe('retreat config', () => {
+  beforeEach(async () => {
+    await setupDb();
+  });
+
+  it('serves sensible defaults on an empty settings table', async () => {
+    const { status, json } = await getConfig();
+    expect(status).toBe(200);
+    expect(json.name).toContain('Growth');
+    expect(json.price_adult).toBe(200);
+    expect(json.price_child).toBe(60);
+    expect(json.price_infant).toBe(0);
+    expect(json.registrations_open).toBe(true);
+  });
+
+  it('admin update is reflected by the public config (only changed fields)', async () => {
+    const put = await putConfig({ name: 'Growth & Wisdom 2027', dates: 'July 30 – Aug 1, 2027', price_adult: 250 });
+    expect(put.status).toBe(200);
+    expect(put.json.name).toBe('Growth & Wisdom 2027');
+
+    const { json } = await getConfig();
+    expect(json.name).toBe('Growth & Wisdom 2027');
+    expect(json.dates).toBe('July 30 – Aug 1, 2027');
+    expect(json.price_adult).toBe(250);
+    // Untouched fields keep their defaults.
+    expect(json.tagline).toBe('The Abundant Life');
+    expect(json.price_child).toBe(60);
+  });
+
+  it('register info pricing follows the configured prices', async () => {
+    await putConfig({ price_adult: 300, price_child: 90 });
+    const res = await registerInfo(ctx(methodRequest('GET')));
+    const json = await res.json() as any;
+    expect(res.status).toBe(200);
+    expect(json.pricing.adult.price).toBe(300);
+    expect(json.pricing.child.price).toBe(90);
+  });
+
+  it('requires admin auth to update', async () => {
+    const res = await putRetreat(ctx(jsonRequest({ name: 'Hacked' })));
+    expect(res.status).toBe(401);
+    // GET admin endpoint too
+    const g = await getRetreat(ctx(methodRequest('GET')));
+    expect(g.status).toBe(401);
+  });
+
+  it('rejects an empty name and a negative price', async () => {
+    const empty = await putConfig({ name: '   ' });
+    expect(empty.status).toBe(400);
+    const neg = await putConfig({ price_adult: -5 });
+    expect(neg.status).toBe(400);
+  });
+
+  it('rejects a payload with no recognised fields', async () => {
+    const res = await putConfig({ nonsense: true });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

The retreat **name, theme, scripture, dates, venue, host and pricing** were hardcoded across the login page, registration page, and the server-side price calculation. This makes them **editable from an admin Settings page**, stored in the `settings` key-value table (which survives the annual "Start New Season" reset) — so each year's details update with **no redeploy**.

## Backend
- **`_shared/retreat-config.ts`** — typed config with sensible defaults, single-query read, partial write.
- **`GET /api/config`** (public) — name / theme / scripture / dates / venue / host / prices + `registrations_open`, consumed by the login and registration pages.
- **`GET`/`PUT /api/admin/settings/retreat`** — read/update with validation (non-empty text, price bounds 0–100000) + audit log.
- **`register.ts`** now prices registrations from the config, so the **charged total always matches the displayed prices**.

## Frontend
- **Login** and **registration** pages fetch `/api/config` and populate name, theme, scripture, dates, venue, host, and the price cards via `[data-config]` hooks. Baked-in defaults remain if the fetch fails (no blank flash of broken content).
- New admin **"Settings" tab** with a Retreat Information form (loads current values, saves changes).

## Tests
Config defaults, admin update reflected in the public config, register pricing follows config, auth + validation (empty name / negative price / no-op payload). **118 tests pass**, `tsc` clean.

## How you'll use it next year
Admin → **Settings** → edit the name/dates/theme/pricing → Save. The login and registration pages immediately show the new year's details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw5d7sghGgqiw96xvzpNFR)_